### PR TITLE
Allow automatic selection of latest base image

### DIFF
--- a/EXAMPLE/ansible.cfg
+++ b/EXAMPLE/ansible.cfg
@@ -1,16 +1,17 @@
 [defaults]
 forks = 50
-force_handlers = True
+force_handlers = yes
 vault_password_file = .vaultpass-client.py
 ;vault_identity_list = sandbox@.vaultpass-client.py, tools@.vaultpass-client.py, dev@.vaultpass-client.py, stage@.vaultpass-client.py, prod@.vaultpass-client.py
-host_key_checking = False
+host_key_checking = no
 force_valid_group_names = ignore
 roles_path = ./roles
 interpreter_python = auto
+callbacks_enabled = ansible.posix.profile_tasks
+pipelining = yes
 
 [ssh_connection]
-retries=5
+retries=10
 ssh_args = -o 'UserKnownHostsFile=/dev/null' -o 'ControlMaster=auto' -o 'ControlPersist=60s'
 #ssh_args = -o 'UserKnownHostsFile=/dev/null' -o 'ControlMaster=auto' -o 'ControlPersist=60s' -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i <proxy_cert> -W %h:%p -q <user>@<host>>"      ##To use with bastion
-pipelining = True
 control_path_dir=/tmp/.ansible/cp

--- a/EXAMPLE/cluster_defs/aws/testid/eu-west-1/cluster_vars__region.yml
+++ b/EXAMPLE/cluster_defs/aws/testid/eu-west-1/cluster_vars__region.yml
@@ -1,8 +1,11 @@
 ---
 
-_ubuntu2004image: "ami-03caf24deed650e2c"                # eu-west-1 20.04, amd64, hvm-ssd, 20210621.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
-_centos7image: "ami-01f35c358a86763b2"                   # eu-west-1 CentOS 7 by Banzai Cloud
-_alma8image: "ami-05d7345cebf7a784f"                     # eu-west-1 Official AlmaLinux 8.x OS image
+_ubuntu2004image: "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*"     # Latest official Canonical Ubuntu Focal (20.04.x) image
+_centos7image: "161831738826/centos-7-pke-*"                                    # Latest 'Banzai Cloud' CentOS 7.x image
+_alma8image: "764336703387/AlmaLinux OS 8.*"                                    # Latest official AlmaLinux 8.x OS image
+#_ubuntu2004image: "ami-03caf24deed650e2c"                # eu-west-1 20.04, amd64, hvm-ssd, 20210621.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+#_centos7image: "ami-01f35c358a86763b2"                   # eu-west-1 CentOS 7 by Banzai Cloud
+#_alma8image: "ami-05d7345cebf7a784f"                     # eu-west-1 Official AlmaLinux 8.x OS image
 
 cluster_vars:
   image: "{{_ubuntu2004image}}"

--- a/EXAMPLE/cluster_defs/esxifree/testid/cluster_vars__clusterid.yml
+++ b/EXAMPLE/cluster_defs/esxifree/testid/cluster_vars__clusterid.yml
@@ -26,6 +26,7 @@ cluster_vars:
 #    - name: user2
 #      lock_passwd: false
 #      passwd: $6$j212wezy...m2RrkJPb9BZMN1O/
+  delete_cloudinit: True
   custom_tagslabels:
     inv_resident_id: "myresident"
     inv_proposition_id: "myproposition"

--- a/EXAMPLE/cluster_defs/gcp/cluster_vars__cloud.yml
+++ b/EXAMPLE/cluster_defs/gcp/cluster_vars__cloud.yml
@@ -1,8 +1,11 @@
 ---
 
-_ubuntu2004image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20210702"
-_centos7image: "projects/centos-cloud/global/images/centos-7-v20210701"
-_alma8image: "projects/almalinux-cloud/global/images/almalinux-8-v20210701"
+_ubuntu2004image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-*"      # Latest Ubuntu Focal (20.04.x) image
+_centos7image: "projects/centos-cloud/global/images/centos-7-*"                     # Latest CentOS 7.x image
+_alma8image: "projects/almalinux-cloud/global/images/almalinux-8-*"                 # Latest AlmaLinux 8.x OS image
+#_ubuntu2004image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20210702"
+#_centos7image: "projects/centos-cloud/global/images/centos-7-v20210701"
+#_alma8image: "projects/almalinux-cloud/global/images/almalinux-8-v20210701"
 
 cluster_vars:
   image: "{{_ubuntu2004image}}"

--- a/EXAMPLE/cluster_defs/gcp/testid/europe-west4/sandbox/cluster_vars__buildenv.yml
+++ b/EXAMPLE/cluster_defs/gcp/testid/europe-west4/sandbox/cluster_vars__buildenv.yml
@@ -29,16 +29,16 @@ cluster_vars:
         auto_volumes: [ ]
         flavor: "e2-micro"
         version: "{{sys_version | default('')}}"
-        vms_by_az: { d: 1, b: 1, c: 0 }
+        vms_by_az: { a: 1, b: 1, c: 0 }
 
       sysdisks2:
         auto_volumes:
-          - { auto_delete: true, interface: "SCSI", volume_size: 1, mountpoint: "/media/mysvc", fstype: "ext4", perms: { owner: "root", group: "root", mode: "775" } }
+          - { auto_delete: true, interface: "SCSI", volume_size: 1, mountpoint: "/media/mysvc1", fstype: "ext4", perms: { owner: "root", group: "root", mode: "775" } }
           - { auto_delete: true, interface: "SCSI", volume_size: 1, mountpoint: "/media/mysvc2", fstype: "ext4" }
         flavor: "e2-micro"
         rootvol_size: "25"              # This is optional, and if set, MUST be bigger than the original image size (20GB on GCP)
         version: "{{sysdisks_version | default('')}}"
-        vms_by_az: { d: 1, b: 1, c: 0 }
+        vms_by_az: { a: 1, b: 1, c: 0 }
 
       sysdiskslvm:
         auto_volumes:
@@ -48,7 +48,7 @@ cluster_vars:
         flavor: "e2-micro"
         rootvol_size: "25"              # This is optional, and if set, MUST be bigger than the original image size (20GB on GCP)
         version: "{{sysdisks_version | default('')}}"
-        vms_by_az: { d: 1, b: 1, c: 0 }
+        vms_by_az: { a: 1, b: 1, c: 0 }
 
 _gcp_service_account_rawtext: *gcp_service_account_rawtext
 _host_ssh_connection_cfg: { <<: *host_ssh_connection_cfg }

--- a/EXAMPLE/cluster_defs/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/cluster_defs/test_aws_euw1/cluster_vars.yml
@@ -50,8 +50,13 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 
 cluster_vars:
   type: &cloud_type "aws"
-  image: "ami-03caf24deed650e2c"      # eu-west-1 20.04 amd64 hvm-ssd 20210621.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
-#  image: "ami-0b850cf02cc00fdc8"      # eu-west-1, CentOS7
+  # Either specify absolute image AMIs, or find the latest images based on location name filter.
+  image: "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*"     # Latest official Canonical Ubuntu Focal (20.04.x) image
+  #image: "161831738826/centos-7-pke-*"                                 # Latest 'Banzai Cloud' CentOS 7.x image
+  #image: "764336703387/AlmaLinux OS 8.*"                               # Latest official AlmaLinux 8.x OS image
+  #image: "ami-03caf24deed650e2c"                   # eu-west-1 20.04 amd64 hvm-ssd 20210621.  Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
+  #image: "ami-01f35c358a86763b2"                   # eu-west-1 CentOS 7 by Banzai Cloud
+  #image: "ami-05d7345cebf7a784f"                   # eu-west-1 Official AlmaLinux 8.x OS image
   region: &region "eu-west-1"
   dns_cloud_internal_domain: "{{_region}}.compute.internal"       # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)

--- a/EXAMPLE/cluster_defs/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/cluster_defs/test_gcp_euw1/cluster_vars.yml
@@ -50,8 +50,12 @@ cluster_name: "{{app_name}}-{{buildenv}}"       # Identifies the cluster within 
 
 cluster_vars:
   type: &cloud_type "gcp"
-  image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20210623"                     # Ubuntu images can be located at https://cloud-images.ubuntu.com/locator/
-#  image: "projects/ubuntu-os-cloud/global/images/centos-7-v20201216
+  image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-*"      # Latest Ubuntu Focal (20.04.x) image
+  #image: "projects/centos-cloud/global/images/centos-7-*"                  # Latest CentOS 7.x image
+  #image: "projects/almalinux-cloud/global/images/almalinux-8-*"            # Latest AlmaLinux 8.x OS image
+  #image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20210702"
+  #image: "projects/centos-cloud/global/images/centos-7-v20210701"
+  #image: "projects/almalinux-cloud/global/images/almalinux-8-v20210701"
   region: &region "europe-west1"
   dns_cloud_internal_domain: "c.{{ (_gcp_service_account_rawtext | string | from_json).project_id }}.internal"         # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                                                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)

--- a/EXAMPLE/cluster_defs/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/cluster_defs/test_gcp_euw1/cluster_vars.yml
@@ -56,7 +56,7 @@ cluster_vars:
   #image: "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20210702"
   #image: "projects/centos-cloud/global/images/centos-7-v20210701"
   #image: "projects/almalinux-cloud/global/images/almalinux-8-v20210701"
-  region: &region "europe-west1"
+  region: &region "europe-west4"
   dns_cloud_internal_domain: "c.{{ (_gcp_service_account_rawtext | string | from_json).project_id }}.internal"         # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                                                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
   dns_user_domain: "{%- if _dns_nameserver_zone -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
@@ -94,9 +94,9 @@ cluster_vars:
       description: "Prometheus instances attached to {{cluster_name}}-nwtag can access the exporter port(s)."
   sandbox:
     hosttype_vars:
-      sys: {vms_by_az: {d: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sys_version | default('''')}}', auto_volumes: []}
-      sysdisks2: {vms_by_az: {d: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sysdisks_version | default('''')}}', rootvol_size: '25', auto_volumes: [{auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc, fstype: ext4, perms: {owner: root, group: root, mode: '775'}}, {auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc2, fstype: ext4}]}
-      sysdisks3: {vms_by_az: {d: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sysdisks_version | default('''')}}', auto_volumes: [{auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc, fstype: ext4}, {auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc2, fstype: ext4}, {auto_delete: true, interface: SCSI, volume_size: 3, mountpoint: /media/mysvc3, fstype: ext4}]}
+      sys: {vms_by_az: {a: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sys_version | default('''')}}', auto_volumes: []}
+      sysdisks2: {vms_by_az: {a: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sysdisks_version | default('''')}}', rootvol_size: '25', auto_volumes: [{auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc, fstype: ext4, perms: {owner: root, group: root, mode: '775'}}, {auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc2, fstype: ext4}]}
+      sysdisks3: {vms_by_az: {a: 1, b: 1, c: 0}, flavor: e2-micro, version: '{{sysdisks_version | default('''')}}', auto_volumes: [{auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc, fstype: ext4}, {auto_delete: true, interface: SCSI, volume_size: 1, mountpoint: /media/mysvc2, fstype: ext4}, {auto_delete: true, interface: SCSI, volume_size: 3, mountpoint: /media/mysvc3, fstype: ext4}]}
     gcp_service_account_rawtext: &gcp_service_account_rawtext !vault |
       $ANSIBLE_VAULT;1.2;AES256;sandbox
       7669080460651349243347331538721104778691266429457726036813912140404310

--- a/EXAMPLE/jenkinsfiles/Jenkinsfile_ops
+++ b/EXAMPLE/jenkinsfiles/Jenkinsfile_ops
@@ -51,7 +51,7 @@ properties([
         parameters([
                 string(name: 'APP_NAME', description: "An optional custom app_name to override the default in the playbook"),
                 booleanParam(name: 'APPEND_BUILD_NUMBER', defaultValue: false, description: 'Tick the box to append the Jenkins BUILD_NUMBER to APP_NAME'),
-                choice(name: 'CLOUD_REGION', choices: ['esxifree/dougalab', 'aws/eu-west-1', 'azure/westeurope', 'gcp/europe-west1'], description: "Choose a cloud/region"),
+                choice(name: 'CLOUD_REGION', choices: ['esxifree/dougalab', 'aws/eu-west-1', 'azure/westeurope', 'gcp/europe-west4'], description: "Choose a cloud/region"),
                 choice(name: 'BUILDENV', choices: ['sandbox', 'dev', 'stage', 'prod'], description: "Choose an environment to deploy"),
                 string(name: 'CLUSTER_ID', defaultValue: '', description: "Select a cluster_id to deploy", trim: true),
                 booleanParam(name: 'DNS_FORCE_DISABLE', defaultValue: false, description: 'Tick the box to force disable the DNS as defined in playbook'),

--- a/EXAMPLE/roles/testrole/tasks/main.yml
+++ b/EXAMPLE/roles/testrole/tasks/main.yml
@@ -3,5 +3,7 @@
 - name: Debug role path
   debug: msg="{{role_path}}"
 
-- name: Debug hosttype_vars
-  debug: msg="{{cluster_vars[buildenv].hosttype_vars}}"
+- name: Forcibly fail (-e testfail=fail_3)
+  fail:
+    msg: testfail=fail_3
+  when: testfail is defined and testfail == "fail_3"

--- a/_dependencies/filter_plugins/custom.py
+++ b/_dependencies/filter_plugins/custom.py
@@ -39,33 +39,10 @@ def iplookup(fqdn):
         import dns.resolver
         return to_text(dns.resolver.query(fqdn, 'A')[0])
 
-# Returns a json object from a loosely defined string (e.g. encoded using single quotes instead of double), or an object containing "AnsibleUnsafeText"
-def json_loads_loose(inStr):
-    import re, json, sys
-
-    display.vv(u"json_loads_loose - input type: %s; value %s" % (type(inStr), inStr))
-    if type(inStr) is dict or type(inStr) is list:
-        json_object = json.loads((to_text(json.dumps(inStr))).encode('utf-8'))
-    else:
-        try:
-            json_object = json.loads(inStr)
-        except (ValueError, AttributeError, TypeError) as e:
-            try:
-                json_object = json.loads(to_text(re.sub(r'\'(.*?)\'([,:}])', r'"\1"\2', inStr).replace(': True', ': "True"').replace(': False', ': "False"')).encode('utf-8'))
-            except (ValueError, AttributeError, TypeError) as e:
-                display.warning(u"json_loads_loose - WARNING: could not parse attribute string (%s) as json: %s" % (to_native(inStr), to_native(e)))
-                return inStr
-        except:
-            e = sys.exc_info()[0]
-            display.warning(u"json_loads_loose - WARNING: could not parse attribute string (%s) as json: %s" % (to_native(inStr), to_native(e)))
-            return inStr
-    return json_object
-
 
 class FilterModule(object):
     def filters(self):
         return {
             'dict_agg': dict_agg,
-            'iplookup': iplookup,
-            'json_loads_loose': json_loads_loose
+            'iplookup': iplookup
         }

--- a/_dependencies/library/esxifree_guest.py
+++ b/_dependencies/library/esxifree_guest.py
@@ -844,7 +844,6 @@ class esxiFreeScraper(object):
                         vmxDict.update({"scsi0:" + str(scsiDiskIdx) + ".devicetype": "scsi-hardDisk"})
                         vmxDict.update({"scsi0:" + str(scsiDiskIdx) + ".present": "TRUE"})
                         vmxDict.update({"scsi0:" + str(scsiDiskIdx) + ".filename": disk_filename})
-                        curDisksCount = curDisksCount + 1
 
         self.put_vmx(vmxDict, vmxPath)
         self.esxiCnx.exec_command("vim-cmd vmsvc/reload " + str(self.moid))

--- a/_dependencies/library/warn_str.py
+++ b/_dependencies/library/warn_str.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Dougal Seeley <github@dougalseeley.com>
+# BSD 3-Clause License
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: warn_str
+version_added: 1.0.0
+description:
+    - Print a deprecation warning to the console on demand
+authors:
+    - Dougal Seeley <github@dougalseeley.com>
+'''
+
+EXAMPLES = '''
+- warn_str:
+    msg: "asdf is not really a word"
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(argument_spec={"msg": {"type": "str", "default": "Warn, world"}})
+
+    module.warn(module.params['msg'])
+
+    module.exit_json(changed=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -19,12 +19,19 @@
         - deprecate_str: { msg: "Loading variables via group_vars/clusterid is deprecated.  Please use merge_vars via cluster_defs in future" }
       when: merge_dict_vars_list is not defined
 
+    - name: argv
+      debug: msg={{ argv }}
+
+    - name: cluster_vars_override
+      debug: msg={{cluster_vars_override}}
+      when: cluster_vars_override is defined
 
     - name: Combine command-line cluster_vars_override into the loaded cluster_vars
       set_fact:
-        cluster_vars: "{{cluster_vars | combine(_cluster_vars_override_templated, recursive=True)}}"
+        cluster_vars: "{{cluster_vars | combine({item.key: item.value | from_yaml}, recursive=True)}}"      # Do the combine with individually parsed variables, because sometimes, the 'value' field of an individual dict is still a string (e.g. during redeploy, which passes the cluster_vars_override again).
       vars:
-        _cluster_vars_override_templated: "{{cluster_vars_override}}"     #This pre-templating technique is needed because sometimes the command-line parameters are interpolated as a string, sometimes as a dict - this normalises them as a dict (which the 'combine' filter, above, requires).
+        _cluster_vars_override_templated: "{{cluster_vars_override}}"     #This pre-templating technique is needed because sometimes the command-line is interpolated as a string, sometimes as a dict - this normalises it as a dict (which the 'combine' filter, above, requires), however the nested parameters may *still* be stringified (as above).
+      with_dict: "{{_cluster_vars_override_templated}}"
       when: cluster_vars is defined and cluster_vars_override is defined and cluster_vars_override != ''
 
 

--- a/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
@@ -14,4 +14,4 @@
 
 - name: get_cluster_hosts_state/aws | Set cluster_hosts_state
   set_fact:
-    cluster_hosts_state: "{{r__ec2_instance_info.instances | json_query(\"[].{name: tags.Name, regionzone: placement.availability_zone, tagslabels: tags, instance_id: instance_id, instance_state: state.name, ipv4: {private: private_ip_address, public: public_ip_address}, disk_info_cloud: block_device_mappings }\") }}"
+    cluster_hosts_state: "{{r__ec2_instance_info.instances | json_query(\"[].{name: tags.Name, regionzone: placement.availability_zone, tagslabels: tags, instance_id: instance_id, instance_state: state.name, ipv4: {private: private_ip_address, public: public_ip_address}, disk_info_cloud: block_device_mappings, cluster_base_image: image_id }\") }}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state_azure.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_azure.yml
@@ -55,7 +55,7 @@
     tenant: "{{cluster_vars[buildenv].azure_tenant}}"
     resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
     name: "{{ item.networkInterface | basename }}"
-  with_items: "{{ r__azure_rm_resource_info.results | to_json | from_json | json_query(\"[].{name: item.name, regionzone: join('-',[item.location,response[0].zones[0]]), tagslabels: item.tags, instance_id: item.id, instance_state: item.power_state, networkInterface: response[0].properties.networkProfile.networkInterfaces[0].id }\") }}"
+  with_items: "{{ r__azure_rm_resource_info.results | to_json | from_json | json_query(\"[].{name: item.name, regionzone: join('-',[item.location,response[0].zones[0]]), tagslabels: item.tags, instance_id: item.id, instance_state: item.power_state, networkInterface: response[0].properties.networkProfile.networkInterfaces[0].id, cluster_base_image: item.image }\") }}"
   register: r__azure_rm_networkinterface_info
   delegate_to: localhost
   run_once: true
@@ -110,4 +110,4 @@
 
 - name: get_cluster_hosts_state/azure | Set cluster_hosts_state
   set_fact:
-    cluster_hosts_state: "{{r__async_status__azure_rm_publicipaddress_info.results | json_query(\"[].{name: item.item.item.item.name, regionzone: item.item.item.item.regionzone, tagslabels: item.item.item.item.tagslabels, instance_id: item.item.item.item.instance_id, instance_state: item.item.item.item.instance_state, ipv4: {private: item.item.networkinterfaces[0].ip_configurations[0].private_ip_address, public: publicipaddresses[0].ip_address} }\") }}"
+    cluster_hosts_state: "{{r__async_status__azure_rm_publicipaddress_info.results | json_query(\"[].{name: item.item.item.item.name, regionzone: item.item.item.item.regionzone, tagslabels: item.item.item.item.tagslabels, instance_id: item.item.item.item.instance_id, instance_state: item.item.item.item.instance_state, ipv4: {private: item.item.networkinterfaces[0].ip_configurations[0].private_ip_address, public: publicipaddresses[0].ip_address}, cluster_base_image: item.item.item.item.cluster_base_image }\") }}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state_esxifree.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_esxifree.yml
@@ -16,9 +16,9 @@
     r__esxifree_guest_info: |
       {% set res = {'virtual_machines': []} -%}
         {%- for result in r__esxifree_guest_info.virtual_machines -%}
-          {%- set loadloose_res = result.annotation | json_loads_loose -%}
-          {%- if loadloose_res | type_debug == 'dict' or loadloose_res | type_debug == 'list' -%}
-            {%- set _ = result.update({'annotation': loadloose_res}) -%}
+          {%- set annotation_parsed = result.annotation | from_yaml -%}
+          {%- if annotation_parsed | type_debug == 'dict' or annotation_parsed | type_debug == 'list' -%}
+            {%- set _ = result.update({'annotation': annotation_parsed}) -%}
             {%- set _ = res.virtual_machines.append(result) -%}
           {%- endif -%}
         {%- endfor -%}

--- a/cluster_hosts/tasks/get_cluster_hosts_state_gcp.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_gcp.yml
@@ -14,13 +14,21 @@
   delegate_to: localhost
   run_once: true
 
+- name: get_cluster_hosts_state/gcp | Get root volume info (for cluster_base_image)
+  gcp_compute_disk_info:
+    zone: "{{item.zone | basename }}"
+    filters: [ "name = {{ item.bootdisk }}" ]
+    project: "{{cluster_vars[buildenv].vpc_project_id}}"
+    auth_kind: "serviceaccount"
+    service_account_file: "{{gcp_credentials_file}}"
+  register: r__gcp_compute_disk_info
+  with_items: "{{ r__gcp_compute_instance_info.results | json_query(\"[?resources[?labels]].resources[].{name: name, bootdisk: disks[?boot].deviceName | [0], zone: zone }\") }}"
+
 - name: get_cluster_hosts_state/gcp | Set cluster_hosts_state with correct regionzone (remove url)
   set_fact:
     cluster_hosts_state: |
-      {% set res = _cluster_hosts_state__urlregion -%}
+      {% set res = r__gcp_compute_instance_info.results | json_query('[?resources[?labels]].resources[].{name: name, regionzone: zone, tagslabels: labels, instance_id: id, instance_state: status, ipv4: {private: networkInterfaces[0].networkIP, public: networkInterfaces[0].accessConfigs[0].natIP}, disk_info_cloud: disks}') -%}
         {%- for cluster_host in res -%}
-           {%- set _ = cluster_host.update({'regionzone': cluster_host.regionzone | regex_replace('^.*/(.*)$', '\\1') }) -%}
+          {%- set _ = cluster_host.update({'regionzone': cluster_host.regionzone | basename, 'cluster_base_image': r__gcp_compute_disk_info.results | json_query('[?item.name==\'' + cluster_host.name + '\'].resources[].sourceImage | [0]') }) -%}
         {%- endfor -%}
       {{ res }}
-  vars:
-    _cluster_hosts_state__urlregion: "{{r__gcp_compute_instance_info.results | json_query(\"[?resources[?labels]].resources[].{name: name, regionzone: zone, tagslabels: labels, instance_id: id, instance_state: status, ipv4: {private: networkInterfaces[0].networkIP, public: networkInterfaces[0].accessConfigs[0].natIP}, disk_info_cloud: disks }\") }}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state_gcp.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_gcp.yml
@@ -3,8 +3,7 @@
 - name: get_cluster_hosts_state/gcp | Get existing instance info (per AZ)
   gcp_compute_instance_info:
     zone: "{{cluster_vars.region}}-{{item}}"
-    filters:
-      - "labels.cluster_name = {{cluster_name}}"
+    filters: [ "labels.cluster_name = {{cluster_name}}" ]
     project: "{{cluster_vars[buildenv].vpc_project_id}}"
     auth_kind: "serviceaccount"
     service_account_file: "{{gcp_credentials_file}}"
@@ -21,8 +20,11 @@
     project: "{{cluster_vars[buildenv].vpc_project_id}}"
     auth_kind: "serviceaccount"
     service_account_file: "{{gcp_credentials_file}}"
+    scopes: ["https://www.googleapis.com/auth/compute.readonly"]
   register: r__gcp_compute_disk_info
   with_items: "{{ r__gcp_compute_instance_info.results | json_query(\"[?resources[?labels]].resources[].{name: name, bootdisk: disks[?boot].deviceName | [0], zone: zone }\") }}"
+  delegate_to: localhost
+  run_once: true
 
 - name: get_cluster_hosts_state/gcp | Set cluster_hosts_state with correct regionzone (remove url)
   set_fact:

--- a/cluster_hosts/tasks/get_cluster_hosts_target_esxifree.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target_esxifree.yml
@@ -6,7 +6,10 @@
       {% set res = [] -%}
       {%- for hosttyped_name, hosttyped in cluster_vars[buildenv].hosttype_vars.items() -%}
         {%- for hostvol in hosttyped.auto_volumes -%}
-          {%- set _dummy = hostvol.update({'volname': hostvol.mountpoint | regex_replace('.*\/(.*)', '\\1')}) -%}
+          {%- if 'lvmparams' in hosttyped -%}
+            {%- set lvm_device_index = '-d' + loop.index|string -%}
+          {%- endif -%}
+          {%- set _dummy = hostvol.update({'volname': hostvol.mountpoint | basename + lvm_device_index|default('')}) -%}
         {%- endfor %}
         {%- for azname, azval in hosttyped.vms_by_az.items() -%}
           {%- if azval | type_debug == 'list' -%}

--- a/config/tasks/disks_auto_cloud.yml
+++ b/config/tasks/disks_auto_cloud.yml
@@ -142,8 +142,9 @@
           filesystem:
             fstype: "{{ raid_vols[0].fstype }}"
             dev: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
-            force: no
-    
+            force: no       # This doesn't appear to prevent the '-F' option being sent to mkfs
+          when: (raid_vols_devices | json_query('[?FSTYPE==``]') | length) == (raid_vols_devices | length)
+
         - name: disks_auto_cloud/lvm | Mount created filesytem(s) persistently
           become: yes
           mount:

--- a/config/tasks/disks_auto_cloud.yml
+++ b/config/tasks/disks_auto_cloud.yml
@@ -1,23 +1,23 @@
 ---
 
-- name: disks_auto_aws_gcp_azure | cluster_hosts_target(inventory_hostname)
+- name: disks_auto_cloud | cluster_hosts_target(inventory_hostname)
   debug: msg={{ cluster_hosts_target | json_query(\"[?hostname == '\" + inventory_hostname + \"'] \") }}
 
-- name: disks_auto_aws_gcp_azure | Mount block devices as individual disks
+- name: disks_auto_cloud | Mount block devices as individual disks
   block:
-    - name: disks_auto_aws_gcp_azure | auto_vols
+    - name: disks_auto_cloud | auto_vols
       debug: msg={{ auto_vols }}
 
-    - name: disks_auto_aws_gcp_azure | Get the block device information (pre-filesystem create)
+    - name: disks_auto_cloud | Get the block device information (pre-filesystem create)
       blockdevmap:
         cloud_type: "{{cluster_vars.type}}"
       become: yes
       register: r__blockdevmap
 
-    - name: disks_auto_aws_gcp_azure | r__blockdevmap (pre-filesystem create)
+    - name: disks_auto_cloud | r__blockdevmap (pre-filesystem create)
       debug: msg={{r__blockdevmap}}
 
-    - name: disks_auto_aws_gcp_azure | Create filesystem (partitionless)
+    - name: disks_auto_cloud | Create filesystem (partitionless)
       become: yes
       filesystem:
         fstype: "{{ item.fstype }}"
@@ -27,16 +27,16 @@
         _dev: "{{ r__blockdevmap.device_map | json_query(\"[?device_name_cloud == '\" + item.device_name + \"' && TYPE=='disk' && parttable_type=='' && FSTYPE=='' && MOUNTPOINT==''].device_name_os | [0]\") }}"
       when: _dev is defined and _dev != ''
 
-    - name: disks_auto_aws_gcp_azure | Get the block device information (post-filesystem create), to get the block IDs for mounting
+    - name: disks_auto_cloud | Get the block device information (post-filesystem create), to get the block IDs for mounting
       blockdevmap:
         cloud_type: "{{cluster_vars.type}}"
       become: yes
       register: r__blockdevmap
 
-    - name: disks_auto_aws_gcp_azure | r__blockdevmap (post-filesystem create)
+    - name: disks_auto_cloud | r__blockdevmap (post-filesystem create)
       debug: msg={{r__blockdevmap}}
 
-    - name: disks_auto_aws_gcp_azure | Mount created filesytem(s) persistently
+    - name: disks_auto_cloud | Mount created filesytem(s) persistently
       become: yes
       mount:
         path: "{{ item.mountpoint }}"
@@ -49,7 +49,7 @@
         _UUID: "{{ r__blockdevmap.device_map | json_query(\"[?device_name_cloud == '\" + item.device_name + \"' && TYPE=='disk' && parttable_type=='' && MOUNTPOINT==''].UUID | [0]\") }}"
       when: _UUID is defined and _UUID != ''
 
-    - name: disks_auto_aws_gcp_azure | change ownership of mountpoint (if set)
+    - name: disks_auto_cloud | change ownership of mountpoint (if set)
       become: yes
       file:
         path: "{{ item.mountpoint }}"
@@ -59,16 +59,16 @@
         group: "{{ item.perms.group | default(omit)}}"
       loop: "{{auto_vols}}"
 
-    - name: disks_auto_aws_gcp_azure | Check that we haven't mounted disks in the wrong place.  Especially useful for redeploys when we're moving disks.
+    - name: disks_auto_cloud | Check that we haven't mounted disks in the wrong place.  Especially useful for redeploys when we're moving disks.
       block:
-        - name: "disks_auto_aws_gcp_azure | Touch a file with the mountpoint and device name for testing that disk attachment is correct.  Note: Use a unique filename here instead of writing to a file, so that more than one file per device is an error.  Note: don't add device_name for GCP, because we can't rename the disks when redeploying and keeping disks (_scheme_rmvm_keepdisk_rollback)"
+        - name: "disks_auto_cloud | Touch a file with the mountpoint and device name for testing that disk attachment is correct.  Note: Use a unique filename here instead of writing to a file, so that more than one file per device is an error.  Note: don't add device_name for GCP, because we can't rename the disks when redeploying and keeping disks (_scheme_rmvm_keepdisk_rollback)"
           become: yes
           file:
             path: "{{item.mountpoint}}/.clusterversetest__{{inventory_hostname | regex_replace('-(?!.*-).*')}}__{{ item.mountpoint | regex_replace('\\/', '_') }}{%- if cluster_vars.type != 'gcp'-%}__{{ item.device_name | regex_replace('\/', '_') }}{%- endif -%}"
             state: touch
           loop: "{{auto_vols}}"
 
-        - name: disks_auto_aws_gcp_azure | Find all .clusterversetest__ files in mounted disks
+        - name: disks_auto_cloud | Find all .clusterversetest__ files in mounted disks
           find:
             paths: "{{item.mountpoint}}"
             hidden: yes
@@ -76,12 +76,12 @@
           loop: "{{auto_vols}}"
           register: r__find_test
 
-        - name: disks_auto_aws_gcp_azure | Check that there is only one .clusterversetest__ file per device in mounted disks.
+        - name: disks_auto_cloud | Check that there is only one .clusterversetest__ file per device in mounted disks.
           block:
-            - name: disks_auto_aws_gcp_azure | testdevicedescriptor
+            - name: disks_auto_cloud | testdevicedescriptor
               debug: msg={{testdevicedescriptor}}
 
-            - name: disks_auto_aws_gcp_azure | assert that only one device descriptor file exists per disk (otherwise, indicates that this run has mapped either more than one device per mount, or a different one to previous)
+            - name: disks_auto_cloud | assert that only one device descriptor file exists per disk (otherwise, indicates that this run has mapped either more than one device per mount, or a different one to previous)
               assert: { that: "testdevicedescriptor | json_query(\"[?length(files) > `1`]\") | length == 0", fail_msg: "ERROR - Exactly one file should exist per storage device.  In error [{{testdevicedescriptor | json_query(\"[?length(files) > `1`]\")}}]" }
           vars:
             testdevicedescriptor: "{{ r__find_test | json_query(\"results[].{hostname: '\" + inventory_hostname + \"', device_name: item.device_name, mountpoint: item.mountpoint, files: files[].path}\") }}"
@@ -92,52 +92,59 @@
 
 
 # The following block mounts all attached volumes that have a single, common mountpoint, by creating a logical volume
-- name: disks_auto_aws_gcp_azure/lvm | Mount block devices in a single LVM mountpoint through LV/VG
+- name: disks_auto_cloud/lvm | Mount block devices in a single LVM mountpoint through LV/VG
   block:
-    - name: disks_auto_aws_gcp_azure/lvm | raid_vols
+    - name: disks_auto_cloud/lvm | raid_vols
       debug: msg={{ raid_vols }}
 
-    - name: disks_auto_aws_gcp_azure/lvm | Install logical volume management tooling. (yum - RedHat/CentOS)
+    - name: disks_auto_cloud/lvm | Install logical volume management tooling. (apt - Debian/Ubuntu)
+      become: true
+      apt:
+        update_cache: yes
+        name: "lvm2"
+      when: ansible_os_family == 'Debian'
+
+    - name: disks_auto_cloud/lvm | Install logical volume management tooling. (yum - RedHat/CentOS)
       become: true
       yum:
         name: "lvm*"
         state: present
       when: ansible_os_family == 'RedHat'
 
-    - name: disks_auto_aws_gcp_azure/lvm | Get the device information (pre-filesystem create)
+    - name: disks_auto_cloud/lvm | Get the device information (pre-filesystem create)
       blockdevmap:
         cloud_type: "{{cluster_vars.type}}"
       become: yes
       register: r__blockdevmap
 
-    - name: disks_auto_aws_gcp_azure/lvm | r__blockdevmap (pre raid create)
+    - name: disks_auto_cloud/lvm | r__blockdevmap (pre raid create)
       debug: msg={{r__blockdevmap}}
 
     - block:
-        - name: disks_auto_aws_gcp_azure/lvm | raid_vols_devices
+        - name: disks_auto_cloud/lvm | raid_vols_devices
           debug: msg={{ raid_vols_devices }}
 
-        - name: disks_auto_aws_gcp_azure/lvm | Create a volume group from all block devices
+        - name: disks_auto_cloud/lvm | Create a volume group from all block devices
           become: yes
           lvg:
             vg:  "{{ lvmparams.vg_name }}"
-            pvs: "{{ raid_vols_devices | map(attribute='device_name_os') | sort  | join(',') }}"
+            pvs: "{{ raid_vols_devices | map(attribute='device_name_os') | sort | join(',') }}"
     
-        - name: disks_auto_aws_gcp_azure/lvm | Create a logical volume from volume group
+        - name: disks_auto_cloud/lvm | Create a logical volume from volume group
           become: yes
           lvol:
             vg: "{{ lvmparams.vg_name }}"
             lv: "{{ lvmparams.lv_name }}"
             size: "{{ lvmparams.lv_size }}"
     
-        - name: disks_auto_aws_gcp_azure/lvm | Create filesystem(s) on attached volume(s)
+        - name: disks_auto_cloud/lvm | Create filesystem(s) on attached volume(s)
           become: yes
           filesystem:
             fstype: "{{ raid_vols[0].fstype }}"
             dev: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
             force: no
     
-        - name: disks_auto_aws_gcp_azure/lvm | Mount created filesytem(s) persistently
+        - name: disks_auto_cloud/lvm | Mount created filesytem(s) persistently
           become: yes
           mount:
             path: "{{ raid_vols[0].mountpoint }}"
@@ -146,15 +153,15 @@
             state: mounted
             opts: _netdev
     
-        - name: disks_auto_aws_gcp_azure/lvm | Check that we haven't mounted disks in the wrong place.  Especially useful for redeploys when we're moving disks.
+        - name: disks_auto_cloud/lvm | Check that we haven't mounted disks in the wrong place.  Especially useful for redeploys when we're moving disks.
           block:
-            - name: "disks_auto_aws_gcp_azure/lvm | Touch a file with the mountpoint for testing that disk attachment is correct.  Note: Use a unique filename here instead of writing to a file, so that more than one file per device is an error."
+            - name: "disks_auto_cloud/lvm | Touch a file with the mountpoint for testing that disk attachment is correct.  Note: Use a unique filename here instead of writing to a file, so that more than one file per device is an error."
               become: yes
               file:
                 path: "{{ raid_vols[0].mountpoint }}/.clusterversetest__{{inventory_hostname | regex_replace('-(?!.*-).*')}}__{{ raid_vols[0].mountpoint | regex_replace('\\/', '_') }}"
                 state: touch
     
-            - name: disks_auto_aws_gcp_azure/lvm | Find all .clusterversetest__ files in mounted disks
+            - name: disks_auto_cloud/lvm | Find all .clusterversetest__ files in mounted disks
               find:
                 paths: "{{ raid_vols[0].mountpoint }}"
                 hidden: yes
@@ -163,7 +170,7 @@
     
             - debug: msg={{r__find_test}}
     
-            - name: disks_auto_aws_gcp_azure/lvm | assert that only one device descriptor file exists per disk (otherwise, indicates that this run has mapped either more than one device per mount, or a different one to previous)
+            - name: disks_auto_cloud/lvm | assert that only one device descriptor file exists per disk (otherwise, indicates that this run has mapped either more than one device per mount, or a different one to previous)
               assert: { that: "'files' in r__find_test != ''  and  r__find_test.files | length == 1", fail_msg: "ERROR - Exactly one file should exist per LVM." }
           when: test_touch_disks is defined and test_touch_disks|bool
       vars:

--- a/config/tasks/disks_auto_generic.yml
+++ b/config/tasks/disks_auto_generic.yml
@@ -9,9 +9,9 @@
 - name: disks_auto_generic | r__blockdevmap
   debug: msg={{ r__blockdevmap }}
 
-- name: disks_auto_generic | Create 'hostvols' fact that contains a list of available host devices (lsblk) mapped to the mountpoints defined in cluster_vars.  Allow for multiple disks with same size.
+- name: disks_auto_generic | Create 'disks_auto_generic__hostvols' fact that contains a list of available host devices (lsblk) mapped to the mountpoints defined in cluster_vars.  Allow for multiple disks with same size.
   set_fact:
-    hostvols: |
+    disks_auto_generic__hostvols: |
       {% set res = [] -%}
       {% set tmp_blkvols = r__blockdevmap.device_map | selectattr('TYPE', '==', 'disk') | selectattr('parttable_type', '==', '') | selectattr('MOUNTPOINT', '==', '') | list -%}
       {% set inventory_hostname__no_suffix = inventory_hostname | regex_replace('-(?!.*-).*') -%}
@@ -27,38 +27,95 @@
       {%- endfor -%}
       {{ res }}
 
-- name: disks_auto_generic | hostvols
-  debug: msg={{hostvols}}
+- name: disks_auto_generic | disks_auto_generic__hostvols
+  debug: msg={{disks_auto_generic__hostvols}}
 
-# Create partition-less filesystems.
-- name: disks_auto_generic | Create filesystem(s) on attached volume(s)
-  become: yes
-  filesystem:
-    fstype: "{{ item.fstype }}"
-    dev: "{{ item.device }}"
-    force: no
-  with_items: "{{ hostvols }}"
-  register: created_filesystem
-  retries: 5
-  delay: 1
-  until: created_filesystem is not failed
+- name: disks_auto_generic | Mount block devices as individual disks
+  block:
+    # Create partition-less filesystems.
+    - name: disks_auto_generic | Create filesystem(s) on attached volume(s)
+      become: yes
+      filesystem:
+        fstype: "{{ item.fstype }}"
+        dev: "{{ item.device }}"
+        force: no
+      with_items: "{{ disks_auto_generic__hostvols }}"
+    
+    - name: disks_auto_generic | Mount created filesytem(s) persistently
+      become: yes
+      mount:
+        path: "{{ item.mountpoint }}"
+        src: "{{ item.device }}"
+        fstype: "{{ item.fstype }}"
+        state: mounted
+        opts: _netdev
+      with_items: "{{ disks_auto_generic__hostvols }}"
+    
+    - name: disks_auto_generic | change ownership of mountpoint (if set)
+      become: yes
+      file:
+        path: "{{ item.mountpoint }}"
+        state: directory
+        mode: "{{ item.perms.mode | default(omit)}}"
+        owner: "{{ item.perms.owner | default(omit)}}"
+        group: "{{ item.perms.group | default(omit)}}"
+      with_items: "{{ disks_auto_generic__hostvols }}"
+  when: (disks_auto_generic__hostvols | map(attribute='mountpoint') | list | unique | count == disks_auto_generic__hostvols | map(attribute='mountpoint') | list | count)
 
-- name: disks_auto_generic | Mount created filesytem(s) persistently
-  become: yes
-  mount:
-    path: "{{ item.mountpoint }}"
-    src: "{{ item.device }}"
-    fstype: "{{ item.fstype }}"
-    state: mounted
-    opts: _netdev
-  with_items: "{{ hostvols }}"
+# The following block mounts all attached volumes that have a single, common mountpoint, by creating a logical volume
+- name: disks_auto_generic/lvm | Mount block devices in a single LVM mountpoint through LV/VG
+  block:
+    - name: disks_auto_cloud/lvm | Install logical volume management tooling. (apt - Debian/Ubuntu)
+      become: true
+      apt:
+        update_cache: yes
+        name: "lvm2"
+      when: ansible_os_family == 'Debian'
 
-- name: disks_auto_generic | change ownership of mountpoint (if set)
-  become: yes
-  file:
-    path: "{{ item.mountpoint }}"
-    state: directory
-    mode: "{{ item.perms.mode | default(omit)}}"
-    owner: "{{ item.perms.owner | default(omit)}}"
-    group: "{{ item.perms.group | default(omit)}}"
-  with_items: "{{ hostvols }}"
+    - name: disks_auto_cloud/lvm | Install logical volume management tooling. (yum - RedHat/CentOS)
+      become: true
+      yum:
+        name: "lvm*"
+        state: present
+      when: ansible_os_family == 'RedHat'
+
+    - block:
+        - name: disks_auto_generic/lvm | raid_vols_devices
+          debug: msg={{ raid_vols_devices }}
+
+        - name: disks_auto_generic/lvm | Create a volume group from all block devices
+          become: yes
+          lvg:
+            vg:  "{{ lvmparams.vg_name }}"
+            pvs: "{{ raid_vols_devices | sort | join(',') }}"
+
+        - name: disks_auto_generic/lvm | Create a logical volume from volume group
+          become: yes
+          lvol:
+            vg: "{{ lvmparams.vg_name }}"
+            lv: "{{ lvmparams.lv_name }}"
+            size: "{{ lvmparams.lv_size }}"
+
+        - name: disks_auto_generic/lvm | Create filesystem(s) on attached volume(s)
+          become: yes
+          filesystem:
+            fstype: "{{ disks_auto_generic__hostvols[0].fstype }}"
+            dev: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
+            force: no
+
+        - name: disks_auto_generic/lvm | Mount created filesytem(s) persistently
+          become: yes
+          mount:
+            path: "{{ disks_auto_generic__hostvols[0].mountpoint }}"
+            src: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
+            fstype: "{{ disks_auto_generic__hostvols[0].fstype }}"
+            state: mounted
+            opts: _netdev
+      vars:
+        raid_vols_devices: "{{ disks_auto_generic__hostvols | map(attribute='device') | list }}"
+      when: raid_vols_devices | length
+
+  when: (lvmparams is defined and lvmparams != {})  and  (disks_auto_generic__hostvols | map(attribute='mountpoint') | list | unique | count == 1) and (disks_auto_generic__hostvols | map(attribute='mountpoint') | list | count >= 2) and (disks_auto_generic__hostvols | map(attribute='fstype') | list | unique | count == 1)
+  vars:
+    _hosttype_vars: "{{ cluster_hosts_target | json_query(\"[?hostname == '\" + inventory_hostname + \"'] | [0]\") }}"
+    lvmparams: "{{ (cluster_vars[buildenv].hosttype_vars[_hosttype_vars.hosttype].lvmparams | default({})) if _hosttype_vars.hosttype is defined else {} }}"

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -58,12 +58,12 @@
   when: (static_journal is defined and static_journal|bool)
 
 - name: Create partition table, format and attach volumes - AWS, GCP or Azure
-  include_tasks: disks_auto_aws_gcp_azure.yml
-  when: cluster_vars.type == "aws" or cluster_vars.type == "gcp" or cluster_vars.type == "azure"
+  include_tasks: disks_auto_cloud.yml
+  when: cluster_vars.type in ["aws", "gcp", "azure"]
 
 - name: Create partition table, format and attach volumes - generic
   include_tasks: disks_auto_generic.yml
-  when: cluster_vars.type != "aws" and cluster_vars.type != "gcp" and cluster_vars.type != "azure"
+  when: cluster_vars.type not in ["aws", "gcp", "azure"]
 
 - name: install prometheus node exporter daemon
   include_tasks: prometheus_node_exporter.yml

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -45,7 +45,7 @@
         spot_wait_timeout: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_wait_timeout | default(10800)}}"    #3 hours
         spot_launch_group: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_launch_group | default(omit)}}"
         spot_type: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_type | default('persistent')}}"
-        image: "{{cluster_vars.image}}"
+        image: "{{ cluster_base_image }}"
         vpc_subnet_id: "{{item.vpc_subnet_id}}"
         assign_public_ip: "{{cluster_vars.assign_public_ip}}"
         group: "{{ cluster_vars.secgroups_existing }} {%- if cluster_vars.secgroup_new | length > 0 -%} + {{ ([r__ec2_group.group_name | default()] | default())}} {%- endif -%}"

--- a/create/tasks/create_azure.yml
+++ b/create/tasks/create_azure.yml
@@ -103,7 +103,7 @@
         resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
         admin_username: "{{cluster_vars[buildenv].ssh_connection_cfg.host.ansible_user}}"
         custom_data : "{{cluster_vars.user_data | default(omit)}}"
-        image: "{{cluster_vars.image}}"
+        image: "{{ cluster_base_image | to_json }}"
         managed_disk_type: Standard_LRS
         name: "{{item.hostname}}"
         os_disk_size_gb: "{{item.os_disk_size_gb | default(omit)}}"

--- a/create/tasks/create_azure.yml
+++ b/create/tasks/create_azure.yml
@@ -164,59 +164,87 @@
 #    - name: create/azure | r__azure_rm_securitygroup
 #      debug: msg={{r__azure_rm_securitygroup}}
 
+    - name: "create/azure | Create and attach managed disk(s) to VM.  NOTE: Cannot do this asynchronously as the API fails when attempting to simultaneously attach multiple disks to a VM."
+      azure.azcollection.azure_rm_manageddisk:
+        client_id: "{{cluster_vars[buildenv].azure_client_id}}"
+        secret: "{{cluster_vars[buildenv].azure_secret}}"
+        subscription_id: "{{cluster_vars[buildenv].azure_subscription_id}}"
+        tenant: "{{cluster_vars[buildenv].azure_tenant}}"
+        resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
+        attach_caching: read_only
+        disk_size_gb: "{{item.auto_volume.disk_size_gb}}"
+        lun: "{{item.auto_volume.device_name}}"
+        managed_by: "{{item.hostname}}"
+        name: "{{_tags.name}}"
+        storage_account_type: "{{item.auto_volume.storage_account_type}}"
+        tags: "{{ _tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
+        zone: "{{item.az_name}}"
+      vars:
+        _tags:
+          name: "{{item.hostname}}--{{ item.auto_volume.mountpoint | basename }}{%- if 'lvmparams' in cluster_vars[buildenv].hosttype_vars[item.hosttype] -%}-d{{ item.auto_volume.device_name | string }}{%- endif -%}"
+          inv_node_version: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].version | default(omit)}}"
+          inv_node_type: "{{item.hosttype}}"
+          owner: "{{ lookup('env','USER') | lower }}"
+          release: "{{ release_version }}"
+      loop: "{{ cluster_hosts_target_denormalised_by_volume }}"
+      register: r__azure_rm_manageddisk
 
-    - name: create/azure | Create and attach managed disk(s) to VM.
-      block:
-        - name: create/azure | Create the managed disk(s) asynchronously
-          azure.azcollection.azure_rm_manageddisk:
-            client_id: "{{cluster_vars[buildenv].azure_client_id}}"
-            secret: "{{cluster_vars[buildenv].azure_secret}}"
-            subscription_id: "{{cluster_vars[buildenv].azure_subscription_id}}"
-            tenant: "{{cluster_vars[buildenv].azure_tenant}}"
-            resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
-            attach_caching: read_only
-            disk_size_gb: "{{item.auto_volume.disk_size_gb}}"
-            name: "{{_tags.name}}"
-            storage_account_type: "{{item.auto_volume.storage_account_type}}"
-            tags: "{{ _tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
-            zone: "{{item.az_name}}"
-          loop: "{{ cluster_hosts_target_denormalised_by_volume }}"
-          register: r__azure_rm_manageddisk_create
-          async: 7200
-          poll: 0
-          vars:
-            _tags:
-              name: "{{item.hostname}}--{{ item.auto_volume.mountpoint | basename }}{%- if 'lvmparams' in cluster_vars[buildenv].hosttype_vars[item.hosttype] -%}-d{{ item.auto_volume.device_name | string }}{%- endif -%}"
-              inv_node_version: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].version | default(omit)}}"
-              inv_node_type: "{{item.hosttype}}"
-              owner: "{{ lookup('env','USER') | lower }}"
-              release: "{{ release_version }}"
+    - name: create/azure | r__azure_rm_manageddisk
+      debug: msg={{r__azure_rm_manageddisk}}
 
-        - name: create/azure | Wait for disks to create
-          async_status: { jid: "{{ item.ansible_job_id }}" }
-          register: r__async_status__r__azure_rm_manageddisk_create
-          until: r__async_status__r__azure_rm_manageddisk_create.finished
-          delay: 3
-          retries: 300
-          with_items: "{{r__azure_rm_manageddisk_create.results}}"
-
-        - name: create/azure | r__async_status__r__azure_rm_manageddisk_create
-          debug: msg={{r__async_status__r__azure_rm_manageddisk_create}}
-
-        - name: "create/azure | Attach managed disk(s) to VM.    Note: Cannot do this at the same time as the asynchronous create, as we cannot simultaneously attach multiple disks to a VM."
-          azure.azcollection.azure_rm_manageddisk:
-            client_id: "{{cluster_vars[buildenv].azure_client_id}}"
-            secret: "{{cluster_vars[buildenv].azure_secret}}"
-            subscription_id: "{{cluster_vars[buildenv].azure_subscription_id}}"
-            tenant: "{{cluster_vars[buildenv].azure_tenant}}"
-            resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
-            attach_caching: "{{item.invocation.module_args.attach_caching}}"   #This must be the same as was used for the azure_rm_manageddisk/create invocation above, or it will detach and reattach the disk creating new mountpoints during redeploy
-            name: "{{item.state.name}}"
-            lun: "{{item.item.item.auto_volume.device_name}}"
-            managed_by: "{{item.item.item.hostname}}"
-          loop: "{{ r__async_status__r__azure_rm_manageddisk_create.results }}"
-          register: r__azure_rm_manageddisk_attach
-
-        - name: create/azure | r__azure_rm_manageddisk_attach
-          debug: msg={{r__azure_rm_manageddisk_attach}}
+##### NOTE: An alternative to the above.  An attempt to speed up the synchronous create an attach by splitting into async create and synchronous attach, but it turns out that create is very fast (~1 second per disk), but attach is the blocker (~30s per disk), so no advantage to more complex code.  Left for reference.
+#    - name: create/azure | Create (asynchronously) and attach (synchronously) managed disk(s) to VM.
+#      block:
+#        - name: create/azure | Create the managed disk(s) asynchronously
+#          azure.azcollection.azure_rm_manageddisk:
+#            client_id: "{{cluster_vars[buildenv].azure_client_id}}"
+#            secret: "{{cluster_vars[buildenv].azure_secret}}"
+#            subscription_id: "{{cluster_vars[buildenv].azure_subscription_id}}"
+#            tenant: "{{cluster_vars[buildenv].azure_tenant}}"
+#            resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
+#            attach_caching: read_only
+#            disk_size_gb: "{{item.auto_volume.disk_size_gb}}"
+#            name: "{{_tags.name}}"
+#            storage_account_type: "{{item.auto_volume.storage_account_type}}"
+#            tags: "{{ _tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
+#            zone: "{{item.az_name}}"
+#          loop: "{{ cluster_hosts_target_denormalised_by_volume }}"
+#          register: r__azure_rm_manageddisk_create
+#          async: 7200
+#          poll: 0
+#          vars:
+#            _tags:
+#              name: "{{item.hostname}}--{{ item.auto_volume.mountpoint | basename }}{%- if 'lvmparams' in cluster_vars[buildenv].hosttype_vars[item.hosttype] -%}-d{{ item.auto_volume.device_name | string }}{%- endif -%}"
+#              inv_node_version: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].version | default(omit)}}"
+#              inv_node_type: "{{item.hosttype}}"
+#              owner: "{{ lookup('env','USER') | lower }}"
+#              release: "{{ release_version }}"
+#
+#        - name: create/azure | Wait for disks to create
+#          async_status: { jid: "{{ item.ansible_job_id }}" }
+#          register: r__async_status__r__azure_rm_manageddisk_create
+#          until: r__async_status__r__azure_rm_manageddisk_create.finished
+#          delay: 3
+#          retries: 300
+#          with_items: "{{r__azure_rm_manageddisk_create.results}}"
+#
+#        - name: create/azure | r__async_status__r__azure_rm_manageddisk_create
+#          debug: msg={{r__async_status__r__azure_rm_manageddisk_create}}
+#
+#        - name: "create/azure | Attach managed disk(s) to VM.    Note: Cannot do this at the same time as the asynchronous create, as we cannot simultaneously attach multiple disks to a VM."
+#          azure.azcollection.azure_rm_manageddisk:
+#            client_id: "{{cluster_vars[buildenv].azure_client_id}}"
+#            secret: "{{cluster_vars[buildenv].azure_secret}}"
+#            subscription_id: "{{cluster_vars[buildenv].azure_subscription_id}}"
+#            tenant: "{{cluster_vars[buildenv].azure_tenant}}"
+#            resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
+#            attach_caching: "{{item.invocation.module_args.attach_caching}}"   #This must be the same as was used for the azure_rm_manageddisk/create invocation above, or it will detach and reattach the disk creating new mountpoints during redeploy
+#            name: "{{item.state.name}}"
+#            lun: "{{item.item.item.auto_volume.device_name}}"
+#            managed_by: "{{item.item.item.hostname}}"
+#          loop: "{{ r__async_status__r__azure_rm_manageddisk_create.results }}"
+#          register: r__azure_rm_manageddisk_attach
+#
+#        - name: create/azure | r__azure_rm_manageddisk_attach
+#          debug: msg={{r__azure_rm_manageddisk_attach}}
 

--- a/create/tasks/create_azure.yml
+++ b/create/tasks/create_azure.yml
@@ -165,30 +165,58 @@
 #      debug: msg={{r__azure_rm_securitygroup}}
 
 
-    - name: create/azure | Create and attach managed disk(s) to VM.  Do NOT ATTEMPT to do this asynchronously - causes issues!
-      azure.azcollection.azure_rm_manageddisk:
-        client_id: "{{cluster_vars[buildenv].azure_client_id}}"
-        secret: "{{cluster_vars[buildenv].azure_secret}}"
-        subscription_id: "{{cluster_vars[buildenv].azure_subscription_id}}"
-        tenant: "{{cluster_vars[buildenv].azure_tenant}}"
-        resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
-        attach_caching: read_only
-        disk_size_gb: "{{item.auto_volume.disk_size_gb}}"
-        lun: "{{item.auto_volume.device_name}}"
-        managed_by: "{{item.hostname}}"
-        name: "{{_tags.name}}"
-        storage_account_type: "{{item.auto_volume.storage_account_type}}"
-        tags: "{{ _tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
-        zone: "{{item.az_name}}"
-      vars:
-        _tags:
-          name: "{{item.hostname}}--{{ item.auto_volume.mountpoint | basename }}"
-          inv_node_version: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].version | default(omit)}}"
-          inv_node_type: "{{item.hosttype}}"
-          owner: "{{ lookup('env','USER') | lower }}"
-          release: "{{ release_version }}"
-      loop: "{{ cluster_hosts_target_denormalised_by_volume }}"
-      register: r__azure_rm_manageddisk
+    - name: create/azure | Create and attach managed disk(s) to VM.
+      block:
+        - name: create/azure | Create the managed disk(s) asynchronously
+          azure.azcollection.azure_rm_manageddisk:
+            client_id: "{{cluster_vars[buildenv].azure_client_id}}"
+            secret: "{{cluster_vars[buildenv].azure_secret}}"
+            subscription_id: "{{cluster_vars[buildenv].azure_subscription_id}}"
+            tenant: "{{cluster_vars[buildenv].azure_tenant}}"
+            resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
+            attach_caching: read_only
+            disk_size_gb: "{{item.auto_volume.disk_size_gb}}"
+            name: "{{_tags.name}}"
+            storage_account_type: "{{item.auto_volume.storage_account_type}}"
+            tags: "{{ _tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
+            zone: "{{item.az_name}}"
+          loop: "{{ cluster_hosts_target_denormalised_by_volume }}"
+          register: r__azure_rm_manageddisk_create
+          async: 7200
+          poll: 0
+          vars:
+            _tags:
+              name: "{{item.hostname}}--{{ item.auto_volume.mountpoint | basename }}{%- if 'lvmparams' in cluster_vars[buildenv].hosttype_vars[item.hosttype] -%}-d{{ item.auto_volume.device_name | string }}{%- endif -%}"
+              inv_node_version: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].version | default(omit)}}"
+              inv_node_type: "{{item.hosttype}}"
+              owner: "{{ lookup('env','USER') | lower }}"
+              release: "{{ release_version }}"
 
-#    - name: create/azure | r__azure_rm_manageddisk
-#      debug: msg={{r__azure_rm_manageddisk}}
+        - name: create/azure | Wait for disks to create
+          async_status: { jid: "{{ item.ansible_job_id }}" }
+          register: r__async_status__r__azure_rm_manageddisk_create
+          until: r__async_status__r__azure_rm_manageddisk_create.finished
+          delay: 3
+          retries: 300
+          with_items: "{{r__azure_rm_manageddisk_create.results}}"
+
+        - name: create/azure | r__async_status__r__azure_rm_manageddisk_create
+          debug: msg={{r__async_status__r__azure_rm_manageddisk_create}}
+
+        - name: "create/azure | Attach managed disk(s) to VM.    Note: Cannot do this at the same time as the asynchronous create, as we cannot simultaneously attach multiple disks to a VM."
+          azure.azcollection.azure_rm_manageddisk:
+            client_id: "{{cluster_vars[buildenv].azure_client_id}}"
+            secret: "{{cluster_vars[buildenv].azure_secret}}"
+            subscription_id: "{{cluster_vars[buildenv].azure_subscription_id}}"
+            tenant: "{{cluster_vars[buildenv].azure_tenant}}"
+            resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
+            attach_caching: "{{item.invocation.module_args.attach_caching}}"   #This must be the same as was used for the azure_rm_manageddisk/create invocation above, or it will detach and reattach the disk creating new mountpoints during redeploy
+            name: "{{item.state.name}}"
+            lun: "{{item.item.item.auto_volume.device_name}}"
+            managed_by: "{{item.item.item.hostname}}"
+          loop: "{{ r__async_status__r__azure_rm_manageddisk_create.results }}"
+          register: r__azure_rm_manageddisk_attach
+
+        - name: create/azure | r__azure_rm_manageddisk_attach
+          debug: msg={{r__azure_rm_manageddisk_attach}}
+

--- a/create/tasks/create_azure.yml
+++ b/create/tasks/create_azure.yml
@@ -103,7 +103,7 @@
         resource_group: "{{cluster_vars[buildenv].azure_resource_group}}"
         admin_username: "{{cluster_vars[buildenv].ssh_connection_cfg.host.ansible_user}}"
         custom_data : "{{cluster_vars.user_data | default(omit)}}"
-        image: "{{ cluster_base_image | to_json }}"
+        image: "{{ cluster_base_image }}"
         managed_disk_type: Standard_LRS
         name: "{{item.hostname}}"
         os_disk_size_gb: "{{item.os_disk_size_gb | default(omit)}}"

--- a/create/tasks/create_esxifree.yml
+++ b/create/tasks/create_esxifree.yml
@@ -6,7 +6,7 @@
     username: "{{ cluster_vars.username }}"
     password: "{{ cluster_vars.password }}"
     datastore: "{{ cluster_vars.datastore }}"
-    template: "{{ cluster_vars.image }}"
+    template: "{{ cluster_base_image }}"
     name: "{{ item.hostname }}"
     state: present
     hardware: "{{ {'version': cluster_vars.hardware_version} | combine({'num_cpus': item.flavor['num_cpus'], 'memory_mb': item.flavor['memory_mb']}) }}"

--- a/create/tasks/create_gcp.yml
+++ b/create/tasks/create_gcp.yml
@@ -103,7 +103,7 @@
         state: present
         deletion_protection: "{{cluster_vars[buildenv].deletion_protection}}"
       vars:
-        _bootdisk: {auto_delete: true, boot: true, device_name: "{{ item.hostname }}--boot", initialize_params: {source_image: "{{cluster_vars.image}}", disk_name: "{{ item.hostname }}--boot", disk_size_gb: "{{ cluster_vars[buildenv].hosttype_vars[item.hosttype].rootvol_size | default(omit) }}"}}
+        _bootdisk: {auto_delete: true, boot: true, device_name: "{{ item.hostname }}--boot", initialize_params: {source_image: "{{cluster_base_image}}", disk_name: "{{ item.hostname }}--boot", disk_size_gb: "{{ cluster_vars[buildenv].hosttype_vars[item.hosttype].rootvol_size | default(omit) }}"}}
         _autodisks: "{{item.auto_volumes | json_query(\"[].{auto_delete: auto_delete, interface: interface, device_name: device_name, initialize_params: initialize_params, source: {selfLink: src.source_url}}\") }}"
         _labels:
           name: "{{item.hostname}}"

--- a/create/tasks/getimg_aws.yml
+++ b/create/tasks/getimg_aws.yml
@@ -4,6 +4,9 @@
   block:
     - name: create/getimg/aws | Attempt to find AMI from cluster_vars.image
       ec2_ami_info:
+        aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+        aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+        region: "{{cluster_vars.region}}"
         filters: { image-id: "{{ cluster_vars.image }}" }
       register: r__ec2_ami_info__by_imageid
 
@@ -14,6 +17,9 @@
 
         - name: create/getimg/aws | Search for ami by using cluster_vars.image as a 'manifest-location'
           ec2_ami_info:
+            aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+            aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+            region: "{{cluster_vars.region}}"
             filters: { manifest-location: "{{ cluster_vars.image }}", architecture: "{{ansible_architecture}}" }
           register: r__ec2_ami_info__by_location
 

--- a/create/tasks/getimg_aws.yml
+++ b/create/tasks/getimg_aws.yml
@@ -1,0 +1,29 @@
+---
+
+- name: create/getimg/aws | cluster_vars.image can either be an AMI in its own right, or a filter to the latest AMI found in manifest-location...
+  block:
+    - name: create/getimg/aws | Attempt to find AMI from cluster_vars.image
+      ec2_ami_info:
+        filters: { image-id: "{{ cluster_vars.image }}" }
+      register: r__ec2_ami_info__by_imageid
+
+    - name: create/getimg/aws | If cluster_vars.image is not an AMI, try to find it via manifest-location
+      block:
+        - name: create/getimg/aws | get ansible_architecture fact (for localhost)
+          setup: { filter: ansible_architecture }
+
+        - name: create/getimg/aws | Search for ami by using cluster_vars.image as a 'manifest-location'
+          ec2_ami_info:
+            filters: { manifest-location: "{{ cluster_vars.image }}", architecture: "{{ansible_architecture}}" }
+          register: r__ec2_ami_info__by_location
+
+        - block:
+            - debug: msg="create/getimg/aws | Using '{{ repl_image.image_location }}' as cluster_base_image"
+
+            - name: create/getimg/aws | Replace cluster_base_image with the latest AMI found at 'manifest-location'
+              set_fact:
+                cluster_base_image: "{{ repl_image.image_id }}"
+          when: r__ec2_ami_info__by_location.images | length > 0
+          vars:
+            repl_image: "{{ (r__ec2_ami_info__by_location.images | sort(attribute='creation_date'))[-1] }}"
+      when: r__ec2_ami_info__by_imageid.images | length == 0

--- a/create/tasks/getimg_gcp.yml
+++ b/create/tasks/getimg_gcp.yml
@@ -1,0 +1,27 @@
+---
+
+- name: create/getimg/gcp | cluster_vars.image can either be an image location in its own right, or a filter to the latest image...
+  block:
+    - name: create/getimg/gcp | Attempt to find image from cluster_vars.image
+      gcp_compute_image_info:
+        filters:
+          - "name = {{_image.name}}"
+        project: "{{_image.project}}"
+        auth_kind: "serviceaccount"
+        service_account_file: "gcp__dev01-197706.json"
+      register: r__gcp_compute_image_info__by_imageid
+      vars:
+        _image:
+          project: "{{cluster_vars.image | regex_replace('.*projects/(.*?)/.*$', '\\1') }}"
+          name: "{{cluster_vars.image | regex_replace('.*?images/(.*?)$', '\\1') | default('*') }}"
+
+    - block:
+        - debug: msg="create/getimg/gcp | Using '{{ repl_image.selfLink }}' as cluster_base_image"
+
+        - name: create/getimg/gcp | Replace cluster_base_image with the latest image found in the cloud project
+          set_fact:
+            cluster_base_image: "{{ repl_image.selfLink }}"
+      when: r__gcp_compute_image_info__by_imageid.resources | length > 1
+      vars:
+        repl_image: "{{ (r__gcp_compute_image_info__by_imageid.resources | sort(attribute='creationTimestamp'))[-1] }}"
+

--- a/create/tasks/main.yml
+++ b/create/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Ensure that the 'release' tag/label is consistent within a cluster.  Perform this here (rather than roles/clusterverse/cluster_hosts/) to allow redeploy to change the version.
+- name: Ensure that the 'release' tag/label is consistent within a cluster.  Perform this here (rather than roles/clusterverse/cluster_hosts/) to allow redeploy to change the version (i.e. after lifecycle_state is set to retiring).
   block:
     - name: current_release_versions
       debug: msg="{{current_release_versions}}"
@@ -21,10 +21,40 @@
     current_release_versions: "{{ cluster_hosts_state | json_query(\"[?tagslabels.lifecycle_state=='current' && tagslabels.release].tagslabels.release\") | default([]) }}"
 
 
-- name: "Create {{cluster_vars.type}} cluster"
-  include_tasks: "{{cluster_vars.type}}.yml"
+- name: Manage base cluster image.  Either the same as existing cluster (if existing cluster exists), or the one defined in 'cluster_vars.image' (which may be a filter, not an image).  Perform this here (rather than roles/clusterverse/cluster_hosts/) to allow redeploy to change the version (i.e. after lifecycle_state is set to retiring).
+  block:
+    - name: _cluster_base_images
+      debug: msg="{{_cluster_base_images}}"
+
+    - block:
+        - assert: { that: "_cluster_base_images | unique | length <= 1", fail_msg: "Multiple 'current' _cluster_base_images running ({{_cluster_base_images | join(',')}}) - abort" }
+
+        - name: Set the cluster_base_image to that defined in the current cluster
+          set_fact: { cluster_base_image: "{{ _cluster_base_images[0] | default('') }}" }
+
+        - warn_str: msg="Using base image '{{cluster_base_image}}', which was found in use in the cluster, instead of defined 'cluster_vars.image' ({{cluster_vars.image}}), to avoid differing base images in cluster."
+          when: cluster_vars.image != cluster_base_image
+      when: _cluster_base_images | length
+
+    - block:
+        - name: Set the cluster_base_image to cluster_vars.image when no cluster already exists
+          set_fact: { cluster_base_image: "{{ cluster_vars.image }}" }
+
+        - name: Get cloud-specific base-image definition (if defined).
+          include: "{{ item }}"
+          loop: "{{ query('first_found', params) }}"
+          vars: { params: { files: ["getimg_{{cluster_vars.type}}.yml"], skip: true } }
+      when: _cluster_base_images | length == 0
+
+    - debug: msg="cluster_base_image = {{cluster_base_image}}"
   vars:
-    # auto_volumes are normally a list of volumes per host.  We cannot iterate this within a non-nested ansible loop(with_items), so we denormalise/ flatten it into a new one-dimensional list, of each volume, as well as all the parent host information.
+    _cluster_base_images: "{{ cluster_hosts_state | json_query(\"[?tagslabels.lifecycle_state=='current' && cluster_base_image].cluster_base_image\") | default([]) }}"
+
+
+- name: "Create {{cluster_vars.type}} cluster"
+  include_tasks: "create_{{cluster_vars.type}}.yml"
+  vars:
+    # auto_volumes are normally a list of volumes per host (list of list).  We cannot iterate this within a non-nested ansible loop (with_items), so we denormalise/ flatten it into a new one-dimensional list, of each volume, as well as all the parent host information.
     cluster_hosts_target_denormalised_by_volume: |
       {% set res = [] -%}
       {%- for cht_host in cluster_hosts_target -%}
@@ -32,7 +62,7 @@
           {%- set elem = {} -%}
           {%- for cht_host_key in cht_host.keys() -%}
             {%- if cht_host_key != 'auto_volumes' -%}
-              {%- set _ = elem.update({cht_host_key: cht_host[cht_host_key]}) -%}
+              {%- set _ = elem.update({'cht_host_key': cht_host[cht_host_key]}) -%}
             {%- else -%}
               {%- set _ = elem.update({'auto_volume': autovol}) -%}
             {%- endif -%}

--- a/jenkinsfiles/Jenkinsfile_testsuite
+++ b/jenkinsfiles/Jenkinsfile_testsuite
@@ -81,7 +81,7 @@ class MatrixBuilder {
     }
 
     static String generateMD5(String s, int len = 30) {
-        java.security.MessageDigest.getInstance("MD5").digest(s.bytes).encodeHex().toString()[0..(len-1)]
+        java.security.MessageDigest.getInstance("MD5").digest(s.bytes).encodeHex().toString()[0..(len - 1)]
     }
 }
 

--- a/jenkinsfiles/Jenkinsfile_testsuite
+++ b/jenkinsfiles/Jenkinsfile_testsuite
@@ -220,7 +220,7 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
 
                     if (env.IMAGE_TESTED) {
                         cluster_vars_override += [image: "{{${env.IMAGE_TESTED}}}"]
-                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
+                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                     }
 
                     stageBuild.extraVars.put("skip_release_version_check", "true")
@@ -237,7 +237,7 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                     }
 
                     if (cluster_vars_override.size()) {
-                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
+                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                     }
 
                     if (env.REDEPLOY_SCHEME) {
@@ -257,7 +257,7 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                         //Need to redeploy original cluster (without scaling), to test that scaling works with next redeploy test (canary=none)
                         if (env.SCALEUPDOWN == 'scaleup' || env.SCALEUPDOWN == 'scaledown') {
                             cluster_vars_override.remove("${env.BUILDENV}")
-                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                             stageBuild.extraVars.put("release_version", "2_5_0")
                             stage_cvops('deploy clean original (unscaled) for next test', stageBuild, {
                                 build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString() + " -e clean=_all_")]
@@ -269,7 +269,7 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                             } else if (env.SCALEUPDOWN == 'scaledown') {
                                 cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 0, c: 0]]]]]     // AZ 'b' is set normally
                             }
-                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                         }
 
                         // Run the canary=none redeploy
@@ -336,7 +336,7 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
 
                     if (env.IMAGE_TESTED) {
                         cluster_vars_override += [image: "{{${env.IMAGE_TESTED}}}"]
-                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
+                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                     }
 
                     if (env.REDEPLOY_SCHEME) {
@@ -360,7 +360,7 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                         }
 
                         if (cluster_vars_override.size()) {
-                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                         }
 
                         // Run the split redeploy over all hosttypes
@@ -382,7 +382,7 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                         //Need to redeploy original cluster (without scaling), to test that scaling works with next redeploy test (canary=none)
                         if (env.SCALEUPDOWN == 'scaleup' || env.SCALEUPDOWN == 'scaledown') {
                             cluster_vars_override.remove("${env.BUILDENV}")
-                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                             stageBuild.extraVars.put("release_version", "2_5_0")
                             stage_cvops('deploy clean original (unscaled) for next test', stageBuild, {
                                 build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString() + " -e clean=_all_")]
@@ -394,7 +394,7 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                             } else if (env.SCALEUPDOWN == 'scaledown') {
                                 cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 0, c: 0]]]]]     // AZ 'b' is set normally
                             }
-                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   // Quote the quotes.  NOTE: NO SPACES are allowed in this!!
                         }
 
                         // Run the canary=none redeploy over all hosttypes

--- a/jenkinsfiles/Jenkinsfile_testsuite
+++ b/jenkinsfiles/Jenkinsfile_testsuite
@@ -90,7 +90,7 @@ properties([
         //disableConcurrentBuilds(),
         //pipelineTriggers([pollSCM(ignorePostCommitHooks: true, scmpoll_spec: '''H/30 8-19 * * 1-5''')]),
         parameters([
-                extendedChoice(name: 'CLOUD_REGION', type: 'PT_MULTI_SELECT', value: 'esxifree/dougalab,aws/eu-west-1,gcp/europe-west1,azure/westeurope', description: 'Specify which cloud/region(s) to test', visibleItemCount: 5),
+                extendedChoice(name: 'CLOUD_REGION', type: 'PT_MULTI_SELECT', value: 'esxifree/dougalab,aws/eu-west-1,gcp/europe-west4,azure/westeurope', description: 'Specify which cloud/region(s) to test', visibleItemCount: 5),
                 choice(name: 'BUILDENV', choices: ['', 'dev'], description: "The environment in which to run the tests"),
                 string(name: 'CLUSTER_ID', defaultValue: 'testsuite', trim: true),
                 [name: 'DNS_FORCE_DISABLE', $class: 'ChoiceParameter', choiceType: 'PT_RADIO', description: '', randomName: 'choice-parameter-31196915540455', script: [$class: 'GroovyScript', fallbackScript: [classpath: [], sandbox: true, script: ''], script: [classpath: [], sandbox: true, script: 'return [\'false:selected\',\'true\',\'true,false\']']]],

--- a/jenkinsfiles/Jenkinsfile_testsuite
+++ b/jenkinsfiles/Jenkinsfile_testsuite
@@ -114,14 +114,14 @@ println("User-supplied 'params': \n" + params.inspect() + "\n")
 // A class to hold the status of each stage, so we can fail a stage and be able to run the clean at the end if needed
 class cStageBuild {
     public String result = 'SUCCESS'
-    public HashMap userParams = [:]
+    public HashMap extraVars = [:]
 
-    String getUserParamsString() {
-        String userParamsString = ""
-        this.userParams.each({ paramName, paramVal ->
-            userParamsString += " -e ${paramName}=${paramVal}"
+    String getExtraVarsString() {
+        String extraVarsString = ""
+        this.extraVars.each({ paramName, paramVal ->
+            extraVarsString += " -e ${paramName}=${paramVal}"
         })
-        return (userParamsString + " -vvvv")
+        return (extraVarsString + " -vvvv")
     }
 }
 
@@ -220,13 +220,13 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
 
                     if (env.IMAGE_TESTED) {
                         cluster_vars_override += [image: "{{${env.IMAGE_TESTED}}}"]
-                        stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
                     }
 
-                    stageBuild.userParams.put("skip_release_version_check", "true")
-                    stageBuild.userParams.put("release_version", "1_0_0")
+                    stageBuild.extraVars.put("skip_release_version_check", "true")
+                    stageBuild.extraVars.put("release_version", "1_0_0")
                     stage_cvops('deploy', stageBuild, {
-                        build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                        build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                     })
 
                     // Update the clustervars with new scaled cluster size
@@ -237,30 +237,30 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                     }
 
                     if (cluster_vars_override.size()) {
-                        stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
                     }
 
                     if (env.REDEPLOY_SCHEME) {
-                        stageBuild.userParams.put("release_version", "2_0_0")
+                        stageBuild.extraVars.put("release_version", "2_0_0")
                         stage_cvops('redeploy canary=start', stageBuild, {
-                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                         })
 
                         stage_cvops('redeploy canary=finish', stageBuild, {
-                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                         })
 
                         stage_cvops('redeploy canary=tidy', stageBuild, {
-                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                         })
 
                         //Need to redeploy original cluster (without scaling), to test that scaling works with next redeploy test (canary=none)
                         if (env.SCALEUPDOWN == 'scaleup' || env.SCALEUPDOWN == 'scaledown') {
                             cluster_vars_override.remove("${env.BUILDENV}")
-                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
-                            stageBuild.userParams.put("release_version", "2_5_0")
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("release_version", "2_5_0")
                             stage_cvops('deploy clean original (unscaled) for next test', stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString() + " -e clean=_all_")]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString() + " -e clean=_all_")]
                             })
 
                             //Re-add the scaleup/down cmdline for next redeploy test (canary=none)
@@ -269,13 +269,13 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                             } else if (env.SCALEUPDOWN == 'scaledown') {
                                 cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 0, c: 0]]]]]     // AZ 'b' is set normally
                             }
-                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
                         }
 
                         // Run the canary=none redeploy
-                        stageBuild.userParams.put("release_version", "3_0_0")
+                        stageBuild.extraVars.put("release_version", "3_0_0")
                         stage_cvops('redeploy canary=none (tidy_on_success)', stageBuild, {
-                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                         })
                     } else {
                         stage_cvops('Redeploy not requested', stageBuild, {
@@ -284,7 +284,7 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                     }
 
                     stage_cvops('deploy on top', stageBuild, {
-                        build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                        build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                     })
 
                     if (stageBuild.result == 'SUCCESS' || params.CLEAN_ON_FAILURE == 'true') {
@@ -293,7 +293,7 @@ CVTEST_NOMYHOSTTYPES = new MatrixBuilder([
                                 echo "Stage failure: Running clean-up on cluster..."
                             }
                             catchError {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                             }
                         }
                     }
@@ -336,7 +336,7 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
 
                     if (env.IMAGE_TESTED) {
                         cluster_vars_override += [image: "{{${env.IMAGE_TESTED}}}"]
-                        stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                        stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
                     }
 
                     if (env.REDEPLOY_SCHEME) {
@@ -346,10 +346,10 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                             unstable('Stage failed!  Error was: ' + err)       // OR:  'error "Stage failure"' or 'throw new org.jenkinsci.plugins.workflow.steps.FlowInterruptedException(hudson.model.Result.FAILURE)', but both of these fail all future stages, preventing us calling the clean.
                         }
 
-                        stageBuild.userParams.put("skip_release_version_check", "true")
-                        stageBuild.userParams.put("release_version", "1_0_0")
+                        stageBuild.extraVars.put("skip_release_version_check", "true")
+                        stageBuild.extraVars.put("release_version", "1_0_0")
                         stage_cvops('deploy', stageBuild, {
-                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                            build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                         })
 
                         // Update the clustervars with new scaled cluster size
@@ -360,32 +360,32 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                         }
 
                         if (cluster_vars_override.size()) {
-                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")   //NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
                         }
 
                         // Run the split redeploy over all hosttypes
-                        stageBuild.userParams.put("release_version", "2_0_0")
+                        stageBuild.extraVars.put("release_version", "2_0_0")
                         params.MYHOSTTYPES_LIST.split(',').each({ my_host_type ->
                             stage_cvops("redeploy canary=start ($my_host_type)", stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'start'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                             })
 
                             stage_cvops("redeploy canary=finish ($my_host_type)", stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'finish'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                             })
 
                             stage_cvops("redeploy canary=tidy ($my_host_type)", stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'tidy'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: false), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                             })
                         })
 
                         //Need to redeploy original cluster (without scaling), to test that scaling works with next redeploy test (canary=none)
                         if (env.SCALEUPDOWN == 'scaleup' || env.SCALEUPDOWN == 'scaledown') {
                             cluster_vars_override.remove("${env.BUILDENV}")
-                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
-                            stageBuild.userParams.put("release_version", "2_5_0")
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
+                            stageBuild.extraVars.put("release_version", "2_5_0")
                             stage_cvops('deploy clean original (unscaled) for next test', stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString() + " -e clean=_all_")]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'deploy'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString() + " -e clean=_all_")]
                             })
 
                             //Re-add the scaleup/down cmdline for next redeploy test (canary=none)
@@ -394,14 +394,14 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                             } else if (env.SCALEUPDOWN == 'scaledown') {
                                 cluster_vars_override += ["${env.BUILDENV}": [hosttype_vars: [sys: [vms_by_az: [b: 0, c: 0]]]]]     // AZ 'b' is set normally
                             }
-                            stageBuild.userParams.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replace("\"", "\\\"") + "\\\'")
+                            stageBuild.extraVars.put("cluster_vars_override", "\\\'" + groovy.json.JsonOutput.toJson(cluster_vars_override).replaceAll(/(?<!\}\})\"(?!\{\{)/, /\\\"/) + "\\\'")   // Quote the quotes, unless they're around an ansible var (e.g. {{image}}).  NOTE: NO SPACES are allowed in this!!
                         }
 
                         // Run the canary=none redeploy over all hosttypes
-                        stageBuild.userParams.put("release_version", "3_0_0")
+                        stageBuild.extraVars.put("release_version", "3_0_0")
                         params.MYHOSTTYPES_LIST.split(',').each({ my_host_type ->
                             stage_cvops("redeploy canary=none ($my_host_type) (tidy_on_success)", stageBuild, {
-                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'redeploy'), string(name: 'REDEPLOY_SCHEME', value: (env.REDEPLOY_SCHEME ? env.REDEPLOY_SCHEME : '')), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: my_host_type), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                             })
                         })
 
@@ -411,7 +411,7 @@ CVTEST_MYHOSTTYPES = new MatrixBuilder([
                                     echo "Stage failure: Running clean-up on cluster..."
                                 }
                                 catchError {
-                                    build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getUserParamsString())]
+                                    build job: 'clusterverse/clusterverse-ops', parameters: [string(name: 'APP_NAME', value: "cvtest-${env.BUILD_NUMBER}-${env.BUILD_HASH}"), string(name: 'CLOUD_REGION', value: env.CLOUD_REGION), string(name: 'BUILDENV', value: env.BUILDENV), string(name: 'CLUSTER_ID', value: env.CLUSTER_ID), booleanParam(name: 'DNS_FORCE_DISABLE', value: env.DNS_FORCE_DISABLE), string(name: 'DEPLOY_TYPE', value: 'clean'), string(name: 'REDEPLOY_SCHEME', value: ''), string(name: 'CANARY', value: 'none'), booleanParam(name: 'CANARY_TIDY_ON_SUCCESS', value: true), string(name: 'MYHOSTTYPES', value: ''), string(name: 'CV_GIT_URL', value: CV_OPS_GIT_URL), string(name: 'CV_GIT_BRANCH', value: CV_OPS_GIT_BRANCH), string(name: 'USER_CMDLINE_VARS', value: stageBuild.getExtraVarsString())]
                                 }
                             }
                         }

--- a/readiness/tasks/remove_maintenance_mode_gcp.yml
+++ b/readiness/tasks/remove_maintenance_mode_gcp.yml
@@ -5,7 +5,7 @@
   gcp_compute_instance:
     name: "{{item.name}}"
     project: "{{cluster_vars[buildenv].vpc_project_id}}"
-    zone: "{{ item.regionzone | regex_replace('^.*/(.*)$', '\\1') }}"
+    zone: "{{ item.regionzone | basename }}"
     auth_kind: "serviceaccount"
     service_account_file: "{{gcp_credentials_file}}"
     deletion_protection: "{{cluster_vars[buildenv].deletion_protection}}"

--- a/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/redeploy.yml
+++ b/redeploy/_scheme_addallnew_rmdisk_rollback/tasks/redeploy.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: argv
+  debug: msg="{{ argv }}"
+
 - name: canary==start or canary==none
   block:
     - assert: { that: "non_current_hosts | length == 0", msg: "ERROR - There must be no machines not in the 'current' lifecycle_state.  [non_current_hosts | join(',')]"  }


### PR DESCRIPTION
+ Allow automatic selection of latest base image by a location filter for AWS and GCP (already possible natively in Azure).
+ Look up existing base image if a cluster already exists to prevent added cluster members from having different base images.
+ update lvm to work with non-aws/gcp/azure clouds