### PR TITLE
Enable selecting static or dynamic external IPs.

### DIFF
--- a/EXAMPLE/cluster_defs/aws/cluster_vars__cloud.yml
+++ b/EXAMPLE/cluster_defs/aws/cluster_vars__cloud.yml
@@ -3,7 +3,7 @@
 cluster_vars:
   dns_cloud_internal_domain: "{{region}}.compute.internal"        # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_server: "route53"             # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
-  assign_public_ip: "no"            # Whether a (ephemeral) public IP should be assigned
+  assign_public_ip: no              # Whether a 'dynamic' (will change on stop/start), 'static' (e.g. elastic IP), or no public IP should be assigned.
   inventory_ip: "private"           # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
   user_data: |-
     #cloud-config

--- a/EXAMPLE/cluster_defs/azure/cluster_vars__cloud.yml
+++ b/EXAMPLE/cluster_defs/azure/cluster_vars__cloud.yml
@@ -5,8 +5,8 @@ redeploy_schemes_supported: ['_scheme_addallnew_rmdisk_rollback', '_scheme_addne
 cluster_vars:
   dns_cloud_internal_domain: "ACCOUNTNAME_CHANGEME.onmicrosoft.com"        # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_server: ""                    # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
-  assign_public_ip: "yes"
-  inventory_ip: "public"            # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
+  assign_public_ip: no              # Whether a 'dynamic' (will change on stop/start), 'static' (e.g. elastic IP), or no public IP should be assigned.
+  inventory_ip: "private"           # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
   user_data: |-
     #cloud-config
     system_info:

--- a/EXAMPLE/cluster_defs/gcp/cluster_vars__cloud.yml
+++ b/EXAMPLE/cluster_defs/gcp/cluster_vars__cloud.yml
@@ -11,9 +11,9 @@ _alma8image: "projects/almalinux-cloud/global/images/almalinux-8-*"             
 cluster_vars:
   image: "{{_ubuntu2004image}}"
   dns_cloud_internal_domain: "c.{{ (_gcp_service_account_rawtext | string | from_json).project_id }}.internal"         # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
-  dns_server: "clouddns"                                                                          # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
-  assign_public_ip: "no"
-  inventory_ip: "private"                                                                         # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
+  dns_server: "clouddns"            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
+  assign_public_ip: no              # Whether a 'dynamic' (will change on stop/start), 'static' (e.g. elastic IP), or no public IP should be assigned.
+  inventory_ip: "private"           # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
   ip_forward: "false"
   metadata:
     #The ssh key is either provided on the command line (as 'ansible_ssh_private_key_file'), or as a variable in cluster_vars[buildenv].ssh_connection_cfg.host.ansible_ssh_private_key_file (anchored to _host_ssh_connection_cfg.ansible_ssh_private_key_file); we can slurp the key from either variable, and then ssh-keygen it into the public key (we have to remove the comment though before we add our own, (hence the regex), because this is what gcp expects).

--- a/EXAMPLE/cluster_defs/test_aws_euw1/cluster_vars.yml
+++ b/EXAMPLE/cluster_defs/test_aws_euw1/cluster_vars.yml
@@ -61,9 +61,9 @@ cluster_vars:
   dns_cloud_internal_domain: "{{_region}}.compute.internal"       # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
   dns_user_domain: "{%- if _dns_nameserver_zone -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
-  dns_server: ""                              # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
-  assign_public_ip: "no"                      # Whether a (ephemeral) public IP should be assigned
-  inventory_ip: "private"                     # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
+  dns_server: "route53"             # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
+  assign_public_ip: no              # Whether a (ephemeral) public IP should be assigned
+  inventory_ip: "private"           # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
   instance_profile_name: ""
   user_data: |-
     #cloud-config

--- a/EXAMPLE/cluster_defs/test_gcp_euw1/cluster_vars.yml
+++ b/EXAMPLE/cluster_defs/test_gcp_euw1/cluster_vars.yml
@@ -60,9 +60,9 @@ cluster_vars:
   dns_cloud_internal_domain: "c.{{ (_gcp_service_account_rawtext | string | from_json).project_id }}.internal"         # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                                                    # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
   dns_user_domain: "{%- if _dns_nameserver_zone -%}{{_cloud_type}}-{{_region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)
-  dns_server: "clouddns"                                                                          # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
-  assign_public_ip: "no"
-  inventory_ip: "private"                                                                         # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
+  dns_server: "clouddns"            # Specify DNS server. nsupdate, route53 or clouddns.  If empty string is specified, no DNS will be added.
+  assign_public_ip: no              # Whether a (ephemeral) public IP should be assigned
+  inventory_ip: "private"           # 'public' or 'private', (private in case we're operating in a private LAN).  If public, 'assign_public_ip' must be 'yes'
   ip_forward: "false"
   ssh_whitelist: &ssh_whitelist ['10.0.0.0/8']
   metadata:

--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -68,7 +68,7 @@
       when: "'custom_tagslabels' in cluster_vars"
     - assert: { that: "'{%- for hosttype in cluster_vars[buildenv].hosttype_vars -%}{% if ('version' in cluster_vars[buildenv].hosttype_vars[hosttype]) and (not cluster_vars[buildenv].hosttype_vars[hosttype].version is regex('^[a-z\\d\\-_]{0,63}$')) %}{{cluster_vars[buildenv].hosttype_vars[hosttype].version}}{% endif %}{%- endfor -%}' == ''", fail_msg: "Please ensure cluster_vars[{{buildenv}}].hosttype_vars[hosttype].version is in the set [a-z\\d\\-_], and <63 characters long." }
 
-    - assert: { that: "(cluster_vars.assign_public_ip == 'yes' and cluster_vars.inventory_ip == 'public') or (cluster_vars.inventory_ip == 'private')", fail_msg: "If inventory_ip=='public', 'assign_public_ip' must be 'yes'" }
+    - assert: { that: "(cluster_vars.assign_public_ip in [true, 'dynamic', 'static'] and cluster_vars.inventory_ip == 'public') or (cluster_vars.inventory_ip == 'private')", fail_msg: "If inventory_ip=='public', 'assign_public_ip' must be [true, 'dynamic', 'static']" }
       when: cluster_vars.type == "gcp" or cluster_vars.type == "aws"
 
     - assert: { that: "cluster_vars[buildenv] | json_query(\"hosttype_vars.*.auto_volumes[] | [?contains(`/dev/sdb,/dev/sdc,/dev/sdd,/dev/sde`, device_name) && volume_type!='ephemeral']\") | length == 0", fail_msg: "device_names /dev/sd[b-e] are only allowed for ephemeral volumes in AWS cluster_vars[buildenv].hosttype_vars.  Please start non-ephemeral devices at /dev/sdf." }

--- a/clean/tasks/aws.yml
+++ b/clean/tasks/aws.yml
@@ -20,6 +20,27 @@
         state: "absent"
         instance_ids: "{{ hosts_to_clean | json_query(\"[].instance_id\") }}"
         wait: true
+
+    - name: clean/aws | Get any attached Elastic IPs
+      ec2_eip_info:
+        aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+        aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+        region: "{{ cluster_vars.region }}"
+        filters:
+          public-ip: "{{ hosts_to_clean | json_query(\"[].ipv4.public\") | default([]) }}"
+      register: r__ec2_eip_info
+
+    - name: clean/aws | r__ec2_eip_info
+      debug: msg={{r__ec2_eip_info}}
+
+    - name: clean/aws | Delete Elastic IPs (if any were found)
+      ec2_eip:
+        aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+        aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+        region: "{{ cluster_vars.region }}"
+        ip: "{{ item.public_ip }}"
+        state: absent
+      with_items: "{{ r__ec2_eip_info.addresses }}"
   when: hosts_to_clean | length
 
 

--- a/clean/tasks/gcp.yml
+++ b/clean/tasks/gcp.yml
@@ -3,19 +3,15 @@
 - name: clean/gcp | clean vms
   block:
     - name: clean/gcp | Remove deletion protection
-      command: "gcloud compute instances update {{item.name}} --no-deletion-protection --zone {{ item.regionzone }}"
-      when: cluster_vars[buildenv].deletion_protection | bool
+      gcp_compute_instance:
+        name: "{{item.name}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
+        zone: "{{ item.regionzone }}"
+        auth_kind: "serviceaccount"
+        service_account_file: "{{gcp_credentials_file}}"
+        deletion_protection: 'no'
       with_items: "{{ hosts_to_clean }}"
-
-    #- name: clean/gcp | Remove deletion protection (broken until https://github.com/ansible-collections/ansible_collections_google/pull/163 gets into a release)
-    #  gcp_compute_instance:
-    #    name: "{{item.name}}"
-    #    project: "{{cluster_vars[buildenv].vpc_project_id}}"
-    #    zone: "{{ item.regionzone }}"
-    #    auth_kind: "serviceaccount"
-    #    service_account_file: "{{gcp_credentials_file}}"
-    #    deletion_protection: 'no'
-    #  with_items: "{{ hosts_to_clean }}"
+      when: cluster_vars[buildenv].deletion_protection | bool
 
     - name: clean/gcp | Delete VMs
       gcp_compute_instance:
@@ -37,6 +33,30 @@
       until: async_jobs.finished
       retries: 300
       with_items: "{{r__gcp_compute_instance.results}}"
+
+    - name: clean/gcp | Get any attached static IPs
+      gcp_compute_address_info:
+        auth_kind: "serviceaccount"
+        service_account_file: "{{gcp_credentials_file}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
+        region: "{{cluster_vars.region}}"
+        filters:
+          - address = "{{ item.ipv4.public }}"
+      with_items: "{{ hosts_to_clean }}"
+      register: r__gcp_compute_address_info
+
+    - name: clean/gcp | r__gcp_compute_address_info
+      debug: msg={{ r__gcp_compute_address_info }}
+
+    - name: clean/gcp | Delete static IPs (if any were found)
+      gcp_compute_address:
+        auth_kind: "serviceaccount"
+        service_account_file: "{{gcp_credentials_file}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
+        region: "{{cluster_vars.region}}"
+        name: "{{ item.name }}"
+        state: absent
+      loop: "{{ r__gcp_compute_address_info.results | json_query(\"[].resources[]\") }}"
   when: hosts_to_clean | length
 
 

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -49,7 +49,7 @@
       with_items: |
         {% set res = [] -%}
         {%- for cht_host in cluster_hosts_target -%}
-          {%- for hosted_zone in r__route53_info__zones.HostedZones | json_query('[?Name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
+          {%- for hosted_zone in r__route53_info__zones.HostedZones | default([]) | json_query('[?Name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
             {%- if hosted_zone.Config.PrivateZone|bool == true and 'ipv4_private' in hostvars[cht_host.hostname] -%}
               {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.Config.PrivateZone, 'ipv4': hostvars[cht_host.hostname]['ipv4_private']}) -%}
             {%- elif hosted_zone.Config.PrivateZone|bool == false and 'ipv4_public' in hostvars[cht_host.hostname] -%} 

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -47,7 +47,7 @@
         spot_type: "{{cluster_vars[buildenv].hosttype_vars[item.hosttype].spot.spot_type | default('persistent')}}"
         image: "{{ item.image }}"
         vpc_subnet_id: "{{item.vpc_subnet_id}}"
-        assign_public_ip: "{{cluster_vars.assign_public_ip}}"
+        assign_public_ip: "{{ true if cluster_vars.assign_public_ip in ['dynamic']  else  false }}"
         group: "{{ cluster_vars.secgroups_existing }} {%- if cluster_vars.secgroup_new | length > 0 -%} + {{ ([r__ec2_group.group_name | default()] | default())}} {%- endif -%}"
         wait: yes
         instance_tags: "{{ _instance_tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
@@ -81,8 +81,18 @@
       retries: 300
       with_items: "{{r__ec2.results}}"
 
-#    - name: create/aws | r__async_status__ec2.results
-#      debug: msg={{r__async_status__ec2.results}}
+    - name: create/aws | r__async_status__ec2.results
+      debug: msg={{r__async_status__ec2.results}}
+
+    - name: create/aws | If (cluster_vars.assign_public_ip in [true, 'static']) then associate a new elastic IP with each instance
+      ec2_eip:
+        aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
+        aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
+        region: "{{cluster_vars.region}}"
+        device_id: "{{ item }}"
+        release_on_disassociation: yes
+      loop: "{{ r__async_status__ec2.results | json_query(\"[].tagged_instances[].id\") }}"
+      when: cluster_vars.assign_public_ip in [true, 'static']
 
     - name: create/aws | Set a fact containing the newly-created hosts
       set_fact:

--- a/create/tasks/create_azure.yml
+++ b/create/tasks/create_azure.yml
@@ -109,7 +109,7 @@
         os_disk_size_gb: "{{item.os_disk_size_gb | default(omit)}}"
 #        network_interface_names: "{{r__azure_rm_networkinterface.results | json_query(\"[?item.hostname == `\" + item.hostname + \"`].state.name\") }}"
         open_ports: ["9"]       # tcp/9 is the 'discard' (dev/null) port. It is set because we must put a value in here, otherwise the default tcp/22 is opened to any/any.  azure_rm_securitygroup is set below.
-        public_ip_allocation_method: "{%- if cluster_vars.assign_public_ip == 'yes' -%}Static{%- else -%}Disabled{%- endif -%}"
+        public_ip_allocation_method: "{%- if cluster_vars.assign_public_ip in [true, 'static'] -%}Static{%- elif cluster_vars.assign_public_ip in ['dynamic'] -%}Dynamic{%- else -%}Disabled{%- endif -%}"
         ssh_password_enabled: no
         ssh_public_keys:
           - path: "/home/{{cluster_vars[buildenv].ssh_connection_cfg.host.ansible_user}}/.ssh/authorized_keys"

--- a/create/tasks/create_gcp.yml
+++ b/create/tasks/create_gcp.yml
@@ -82,6 +82,21 @@
         name: "{{item.auto_volume.src.source_url | basename}}"
       loop: "{{ cluster_hosts_target_denormalised_by_volume | selectattr('auto_volume.src', 'defined') | list }}"
 
+    - name: create/gcp | If (cluster_vars.assign_public_ip in [true, 'static']) then create a new static IP for each instance
+      gcp_compute_address:
+        auth_kind: "serviceaccount"
+        service_account_file: "{{gcp_credentials_file}}"
+        project: "{{cluster_vars[buildenv].vpc_project_id}}"
+        region: "{{cluster_vars.region}}"
+        name: "{{ item.hostname }}"
+        state: present
+      register: r__gcp_compute_address
+      loop: "{{ cluster_hosts_target }}"
+      when: cluster_vars.assign_public_ip in [true, 'static']
+
+    - name: create/gcp | r__gcp_compute_address
+      debug: msg={{r__gcp_compute_address}}
+
     - name: create/gcp | Create VMs asynchronously
       gcp_compute_instance:
         auth_kind: "serviceaccount"
@@ -96,7 +111,15 @@
         network_interfaces:
           - network: "{{ r__gcp_compute_network_info['resources'][0] | default({}) }}"
             subnetwork: "{{ r__gcp_compute_subnetwork_info['resources'][0] | default({}) }}"
-            access_configs: "{%- if cluster_vars.assign_public_ip == 'yes' -%}[{\"name\": \"External NAT\", \"type\": \"ONE_TO_ONE_NAT\"}]{%- else -%}[]{%- endif -%}"
+            access_configs: |-
+              {%- set res = [] -%}
+              {%- if cluster_vars.assign_public_ip in [true, 'dynamic', 'static'] -%}
+                {%- set _dummy = res.append({'name': 'External NAT', 'type': 'ONE_TO_ONE_NAT'}) -%}
+                {%- if cluster_vars.assign_public_ip in [true, 'static'] -%}
+                  {%- set _dummy = res[res | length-1].update({'nat_ip': {'address': r__gcp_compute_address.results | json_query('[?name==\'' + item.hostname + '\'] | [0].address') }}) -%}
+                {%- endif -%}
+              {%- endif -%}
+              {{res}}
         tags: { items: "{{cluster_vars.network_fw_tags}}" }
         can_ip_forward: "{{cluster_vars.ip_forward}}"
         scheduling: { automatic_restart: yes, preemptible: "{{cluster_vars[buildenv].preemptible}}" }

--- a/dynamic_inventory/tasks/main.yml
+++ b/dynamic_inventory/tasks/main.yml
@@ -22,7 +22,7 @@
     name: "{{ item.name }}"
     groups: "{{ item.tagslabels.hosttype }},{{ cluster_name }},{{ clusterid }}{% if item.regionzone is defined and item.regionzone %},{{ item.regionzone }}{% endif %}{% if cluster_hosts_target is defined and item.name not in (cluster_hosts_target | default({}) | map(attribute='hostname')) %},not_target_hosts{% endif %}"
     ansible_host: "{{ item.ipv4.public if cluster_vars.inventory_ip=='public' else item.ipv4.private }}"
-    ipv4_public: "{{ item.ipv4.public if cluster_vars.assign_public_ip|bool  else  omit }}"
+    ipv4_public: "{{ item.ipv4.public if cluster_vars.assign_public_ip in [true, 'dynamic', 'static']  else  omit }}"
     ipv4_private: "{{ item.ipv4.private }}"
     hosttype: "{{ item.tagslabels.hosttype }}"
     regionzone: "{{ item.regionzone if item.regionzone else omit }}"

--- a/readiness/tasks/config_dns_cname.yml
+++ b/readiness/tasks/config_dns_cname.yml
@@ -42,7 +42,7 @@
       with_items: |
         {% set res = [] -%}
         {%- for cht_host in cluster_hosts_target -%}
-          {%- for hosted_zone in r__route53_info__zones.HostedZones | json_query('[?Name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
+          {%- for hosted_zone in r__route53_info__zones.HostedZones | default([]) | json_query('[?Name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
             {%- if hosted_zone.Config.PrivateZone|bool == true and 'ipv4_private' in hostvars[cht_host.hostname]  or  hosted_zone.Config.PrivateZone|bool == false and 'ipv4_public' in hostvars[cht_host.hostname] -%} 
               {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.Config.PrivateZone}) -%}
             {%- endif -%}


### PR DESCRIPTION
Previous default was dynamic, which is a problem if VMs stop and start.
+ Enabled the option for Azure (it was already part of the azure_rm_virtualmachine module)
+ Add logic for create and delete of AWS and GCP to add EIP or static IPs respectively.
+ Also fix GCP remove deletion protection
+ Also fix GCP undefined variable when a "when" block evaluates false