### PR TITLE
Deprecations redirects

### DIFF
--- a/EXAMPLE/README.md
+++ b/EXAMPLE/README.md
@@ -7,7 +7,7 @@ _**Please refer to the full [README.md](https://github.com/dseeley/clusterverse/
 Contributions are welcome and encouraged.  Please see [CONTRIBUTING.md](https://github.com/dseeley/clusterverse/blob/master/CONTRIBUTING.md) for details.
 
 ## Requirements
-+ Ansible >= 5.6.0
++ Ansible >= 5.6.0  (**Ansible >= 7.0.0 _strongly recommended_**)
 + Python >= 3.8
 
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A full-lifecycle, immutable cloud infrastructure cluster management **role**, us
 Contributions are welcome and encouraged.  Please see [CONTRIBUTING.md](https://github.com/sky-uk/clusterverse/blob/master/CONTRIBUTING.md) for details.
 
 ## Requirements
++ Ansible >= 5.6.0  (**Ansible >= 7.0.0 _strongly recommended_**)
++ Python >= 3.8
 
 ### Python dependencies
 Dependencies are managed via pipenv:

--- a/_dependencies/vars_plugins/cli_facts.py
+++ b/_dependencies/vars_plugins/cli_facts.py
@@ -23,7 +23,7 @@ import sys
 
 
 class VarsModule(BaseVarsPlugin):
-    REQUIRES_WHITELIST = False
+    REQUIRES_ENABLED = False
 
     def get_vars(self, loader, path, entities, cache=True):
         super(VarsModule, self).get_vars(loader, path, entities)

--- a/clean/tasks/aws.yml
+++ b/clean/tasks/aws.yml
@@ -24,7 +24,7 @@
         wait: true
 
     - name: clean/aws | Get any attached Elastic IPs
-      amazon.aws.ec2_eip_info:
+      community.aws.ec2_eip_info:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{ cluster_vars.region }}"
@@ -36,7 +36,7 @@
       debug: msg={{r__ec2_eip_info}}
 
     - name: clean/aws | Delete Elastic IPs (if any were found)
-      amazon.aws.ec2_eip:
+      community.aws.ec2_eip:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{ cluster_vars.region }}"
@@ -49,7 +49,7 @@
 - name: clean/aws | clean networking (when '-e clean=_all_')
   block:
     - name: clean/aws | Delete security group
-      amazon.aws.ec2_security_group:
+      amazon.aws.ec2_group:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"

--- a/clean/tasks/aws.yml
+++ b/clean/tasks/aws.yml
@@ -24,7 +24,7 @@
         wait: true
 
     - name: clean/aws | Get any attached Elastic IPs
-      ec2_eip_info:
+      amazon.aws.ec2_eip_info:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{ cluster_vars.region }}"
@@ -36,7 +36,7 @@
       debug: msg={{r__ec2_eip_info}}
 
     - name: clean/aws | Delete Elastic IPs (if any were found)
-      ec2_eip:
+      amazon.aws.ec2_eip:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{ cluster_vars.region }}"
@@ -49,7 +49,7 @@
 - name: clean/aws | clean networking (when '-e clean=_all_')
   block:
     - name: clean/aws | Delete security group
-      ec2_group:
+      amazon.aws.ec2_security_group:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"

--- a/clean/tasks/dns.yml
+++ b/clean/tasks/dns.yml
@@ -37,26 +37,26 @@
     - name: "clean/dns/route53 | Delete DNS entries (legacy (faster) mechanism: route53(state=get)/ route53)"
       block:
         - name: clean/dns/route53 | Gather info for pre-existing Hosted Zones (public and/or private)
-          amazon.aws.route53_info:
+          community.aws.route53_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             query: hosted_zone
           register: r__route53_info__zones
 
         - name: clean/dns/route53 | Get A records
-          amazon.aws.route53:
+          community.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "get"
             zone: "{{cluster_vars.dns_nameserver_zone}}"
             record: "{{item.0.name}}.{{cluster_vars.dns_user_domain}}"
             type: "A"
-            private_zone: "{{ item.1.config.private_zone }}"
+            private_zone: "{{ item.1.Config.PrivateZone }}"
           ignore_errors: yes        # In the ansible=4.x versions of route53.py, a failed lookup results in a failure of this route53 module.
           register: r__route53_a
           with_nested:
             - "{{ hosts_to_clean }}"
-            - "{{ r__route53_info__zones.hosted_zones | json_query(\"[?name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
+            - "{{ r__route53_info__zones.HostedZones | json_query(\"[?Name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
 
         - name: clean/dns/route53 | Remove failed DNS lookups from route53 state=get  (this happens with all the ansible=4.x versions of route53.py)
           set_fact:
@@ -64,7 +64,7 @@
           when: r__route53_a is failed
 
         - name: clean/dns/route53 | Delete A records
-          amazon.aws.route53:
+          community.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "absent"
@@ -73,26 +73,26 @@
             type: "{{ item.resource_record_sets.type }}"
             ttl: "{{ item.resource_record_sets.ttl }}"
             value: "{{ item.resource_record_sets.resource_records | json_query(\"[].value\") }}"
-            private_zone: "{{ item.private_zone }}"
+            private_zone: "{{ item.PrivateZone }}"
           with_items: "{{ records_to_clean }}"
           vars:
             _fqdns_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)$', '\\1.' + cluster_vars.dns_user_domain + '.') | list }}"
-            records_to_clean: "{{ r__route53_a.results | json_query(\"[?resource_record_sets[?type=='A' && contains(\"+ _fqdns_to_clean | string +\", name)]].{resource_record_sets: resource_record_sets[?type=='A']|[0], item0name: item[0].name, private_zone: item[1].config.private_zone}\") }}"
+            records_to_clean: "{{ r__route53_a.results | json_query(\"[?resource_record_sets[?type=='A' && contains(\"+ _fqdns_to_clean | string +\", name)]].{resource_record_sets: resource_record_sets[?type=='A']|[0], item0name: item[0].name, PrivateZone: item[1].Config.PrivateZone}\") }}"
 
         - name: clean/dns/route53 | Get CNAME records
-          amazon.aws.route53:
+          community.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "get"
             zone: "{{cluster_vars.dns_nameserver_zone}}"
             record: "{{item.0.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
             type: "CNAME"
-            private_zone: "{{ item.1.config.private_zone }}"
+            private_zone: "{{ item.1.Config.PrivateZone }}"
           ignore_errors: yes        # In the ansible=4.x versions of route53.py, a failed lookup results in a failure of this route53 module.
           register: r__route53_cname
           with_nested:
             - "{{ hosts_to_clean }}"
-            - "{{ r__route53_info__zones.hosted_zones | json_query(\"[?name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
+            - "{{ r__route53_info__zones.HostedZones | json_query(\"[?Name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
 
         - name: clean/dns/route53 | Remove failed DNS lookups from route53 state=get  (this happens with all the ansible=4.x versions of route53.py)
           set_fact:
@@ -100,7 +100,7 @@
           when: r__route53_cname is failed
 
         - name: clean/dns/route53 | Delete CNAME records
-          amazon.aws.route53:
+          community.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "absent"
@@ -109,7 +109,7 @@
             type: "{{ item.1.set.type }}"
             ttl: "{{ item.1.set.ttl }}"
             value: ["{{ item.1.set.value }}"]
-            private_zone: "{{ item.1.item.1.config.private_zone }}"
+            private_zone: "{{ item.1.item.1.Config.PrivateZone }}"
           with_nested:
             - "{{ hosts_to_clean }}"
             - "{{ r__route53_cname.results }}"
@@ -120,7 +120,7 @@
     - name: "clean/dns/route53 | Delete DNS entries (new mechanism: route53_zone/ route53_info/ route53)"
       block:
         - name: clean/dns/route53 | Gather info for pre-existing Hosted Zones (public and/or private)
-          amazon.aws.route53_info:
+          community.aws.route53_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             query: hosted_zone
@@ -129,23 +129,23 @@
         # Note: route53_info currently does not honour the 'max_items' or 'type' fields, (and if 'start_record_name' is not found, it just returns all records), so we need to filter the responses to match 'hosts_to_clean' when doing the delete
         # Note: cannot run route53_info asynchronously as it makes too many concurrent requests and blows the AWS Route53 API limit.
         - name: clean/dns/route53 | Get A records
-          amazon.aws.route53_info:
+          community.aws.route53_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             type: "A"
             max_items: 1
             query: record_sets
-            hosted_zone_id: "{{ item.1.id }}"
+            hosted_zone_id: "{{ item.1.Id }}"
             start_record_name: "{{item.0.name}}.{{cluster_vars.dns_user_domain}}"
           register: r__route53_info__a
           until: r__route53_info__a is success
           retries: 10
           with_nested:
             - "{{ hosts_to_clean }}"
-            - "{{ r__route53_info__zones.hosted_zones | json_query(\"[?name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
+            - "{{ r__route53_info__zones.HostedZones | json_query(\"[?Name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
 
         - name: clean/dns/route53 | Delete A records
-          amazon.aws.route53:
+          community.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "absent"
@@ -153,49 +153,49 @@
             record: "{{ item.resource_record_sets.name }}"
             type: "{{ item.resource_record_sets.type }}"
             ttl: "{{ item.resource_record_sets.ttl }}"
-            value: "{{ item.resource_record_sets.resource_records | json_query(\"[].value\") }}"
+            value: "{{ item.ResourceRecordSets.ResourceRecords | json_query(\"[].Value\") }}"
             private_zone: "{{ item.private_zone }}"
           with_items: "{{ records_to_clean }}"
           vars:
             _fqdns_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)$', '\\1.' + cluster_vars.dns_user_domain + '.') | list }}"
-            records_to_clean: "{{ r__route53_info__a.results | json_query(\"[?resource_record_sets[?type=='A' && contains(\"+ _fqdns_to_clean | string +\", Name)]].{resource_record_sets: resource_record_sets[?type=='A']|[0], item0name: item[0].name, private_zone: item[1].config.private_zone}\") }}"
+            records_to_clean: "{{ r__route53_info__a.results | json_query(\"[?ResourceRecordSets[?Type=='A' && contains(\"+ _fqdns_to_clean | string +\", Name)]].{ResourceRecordSets: ResourceRecordSets[?Type=='A']|[0], item0name: item[0].name, PrivateZone: item[1].Config.PrivateZone}\") }}"
 
         # Note: route53_info currently does not honour the 'max_items' or 'type' fields, (and if 'start_record_name' is not found, it just returns all records), so we need to filter the responses to match 'hosts_to_clean' when doing the delete
         # Note: cannot run route53_info asynchronously as it makes too many concurrent requests and blows the AWS Route53 API limit.
         - name: clean/dns/route53 | Get CNAME records
-          amazon.aws.route53_info:
+          community.aws.route53_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             type: "CNAME"
             max_items: 1
             query: record_sets
-            hosted_zone_id: "{{ item.1.id }}"
+            hosted_zone_id: "{{ item.1.Id }}"
             start_record_name: "{{item.0.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
           register: r__route53_info__cname
           with_nested:
             - "{{ hosts_to_clean }}"
-            - "{{ r__route53_info__zones.hosted_zones | json_query(\"[?name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
+            - "{{ r__route53_info__zones.HostedZones | json_query(\"[?Name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
           until: r__route53_info__cname is success
           retries: 10
 
         - name: clean/dns/route53 | Delete CNAME records
-          amazon.aws.route53:
+          community.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "absent"
             zone: "{{ cluster_vars.dns_nameserver_zone }}"
-            record: "{{ item.1.resource_record_sets.name }}"
-            type: "{{ item.1.resource_record_sets.type }}"
-            ttl: "{{ item.1.resource_record_sets.ttl }}"
-            value: "{{ item.1.resource_record_sets.resource_records | json_query(\"[].value\") }}"
-            private_zone: "{{ item.1.private_zone }}"
+            record: "{{ item.1.ResourceRecordSets.Name }}"
+            type: "{{ item.1.ResourceRecordSets.Type }}"
+            ttl: "{{ item.1.ResourceRecordSets.TTL }}"
+            value: "{{ item.1.ResourceRecordSets.ResourceRecords | json_query(\"[].Value\") }}"
+            private_zone: "{{ item.1.PrivateZone }}"
           with_nested:
             - "{{ hosts_to_clean }}"
             - "{{ records_to_clean }}"
           vars:
             _fqdns_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)-(?!.*-).*$', '\\1.' + cluster_vars.dns_user_domain + '.') | list }}"   #Remove the last '-.*' (cluster_suffix)
-            records_to_clean: "{{ r__route53_info__cname.results | json_query(\"[?resource_record_sets[?type=='CNAME' && contains(\"+ _fqdns_to_clean | string +\", name)]].{resource_record_sets: resource_record_sets[?type=='CNAME']|[0], item0name: item[0].name, private_zone: item[1].config.private_zone}\") }}"
-          when: ((item.0.name | regex_replace('-(?!.*-).*')) == (item.1.resource_record_sets.name | regex_replace('^(.*?)\\..*$', '\\1')))  and  ((item.0.name == item.1.resource_record_sets.resource_records[0].value | regex_replace('^(.*?)\\..*$', '\\1')))
+            records_to_clean: "{{ r__route53_info__cname.results | json_query(\"[?ResourceRecordSets[?Type=='CNAME' && contains(\"+ _fqdns_to_clean | string +\", Name)]].{ResourceRecordSets: ResourceRecordSets[?Type=='CNAME']|[0], item0name: item[0].name, PrivateZone: item[1].Config.PrivateZone}\") }}"
+          when: ((item.0.name | regex_replace('-(?!.*-).*')) == (item.1.ResourceRecordSets.Name | regex_replace('^(.*?)\\..*$', '\\1')))  and  ((item.0.name == item.1.ResourceRecordSets.ResourceRecords[0].Value | regex_replace('^(.*?)\\..*$', '\\1')))
       when: cluster_vars.dns_server == "route53" and (use_new_route53 is defined and use_new_route53|bool)
 
 

--- a/clean/tasks/dns.yml
+++ b/clean/tasks/dns.yml
@@ -7,7 +7,7 @@
     - name: clean/dns/nsupdate | Delete DNS entries
       block:
         - name: clean/dns/nsupdate | Delete A records
-          nsupdate:
+          community.general.nsupdate:
             key_name: "{{cluster_vars[buildenv].nsupdate_cfg.key_name | default(bind9[buildenv].key_name)}}"
             key_secret: "{{cluster_vars[buildenv].nsupdate_cfg.key_secret | default(bind9[buildenv].key_secret)}}"
             server: "{{cluster_vars[buildenv].nsupdate_cfg.server | default(bind9[buildenv].server)}}"
@@ -17,7 +17,7 @@
           with_items: "{{ hosts_to_clean }}"
 
         - name: clean/dns/nsupdate | Delete CNAME records
-          nsupdate:
+          community.general.nsupdate:
             key_name: "{{cluster_vars[buildenv].nsupdate_cfg.key_name | default(bind9[buildenv].key_name)}}"
             key_secret: "{{cluster_vars[buildenv].nsupdate_cfg.key_secret | default(bind9[buildenv].key_secret)}}"
             server: "{{cluster_vars[buildenv].nsupdate_cfg.server | default(bind9[buildenv].server)}}"
@@ -37,26 +37,26 @@
     - name: "clean/dns/route53 | Delete DNS entries (legacy (faster) mechanism: route53(state=get)/ route53)"
       block:
         - name: clean/dns/route53 | Gather info for pre-existing Hosted Zones (public and/or private)
-          route53_info:
+          amazon.aws.route53_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             query: hosted_zone
           register: r__route53_info__zones
 
         - name: clean/dns/route53 | Get A records
-          route53:
+          amazon.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "get"
             zone: "{{cluster_vars.dns_nameserver_zone}}"
             record: "{{item.0.name}}.{{cluster_vars.dns_user_domain}}"
             type: "A"
-            private_zone: "{{ item.1.Config.PrivateZone }}"
+            private_zone: "{{ item.1.config.private_zone }}"
           ignore_errors: yes        # In the ansible=4.x versions of route53.py, a failed lookup results in a failure of this route53 module.
           register: r__route53_a
           with_nested:
             - "{{ hosts_to_clean }}"
-            - "{{ r__route53_info__zones.HostedZones | json_query(\"[?Name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
+            - "{{ r__route53_info__zones.hosted_zones | json_query(\"[?name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
 
         - name: clean/dns/route53 | Remove failed DNS lookups from route53 state=get  (this happens with all the ansible=4.x versions of route53.py)
           set_fact:
@@ -64,7 +64,7 @@
           when: r__route53_a is failed
 
         - name: clean/dns/route53 | Delete A records
-          route53:
+          amazon.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "absent"
@@ -73,26 +73,26 @@
             type: "{{ item.resource_record_sets.type }}"
             ttl: "{{ item.resource_record_sets.ttl }}"
             value: "{{ item.resource_record_sets.resource_records | json_query(\"[].value\") }}"
-            private_zone: "{{ item.PrivateZone }}"
+            private_zone: "{{ item.private_zone }}"
           with_items: "{{ records_to_clean }}"
           vars:
             _fqdns_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)$', '\\1.' + cluster_vars.dns_user_domain + '.') | list }}"
-            records_to_clean: "{{ r__route53_a.results | json_query(\"[?resource_record_sets[?type=='A' && contains(\"+ _fqdns_to_clean | string +\", name)]].{resource_record_sets: resource_record_sets[?type=='A']|[0], item0name: item[0].name, PrivateZone: item[1].Config.PrivateZone}\") }}"
+            records_to_clean: "{{ r__route53_a.results | json_query(\"[?resource_record_sets[?type=='A' && contains(\"+ _fqdns_to_clean | string +\", name)]].{resource_record_sets: resource_record_sets[?type=='A']|[0], item0name: item[0].name, private_zone: item[1].config.private_zone}\") }}"
 
         - name: clean/dns/route53 | Get CNAME records
-          route53:
+          amazon.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "get"
             zone: "{{cluster_vars.dns_nameserver_zone}}"
             record: "{{item.0.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
             type: "CNAME"
-            private_zone: "{{ item.1.Config.PrivateZone }}"
+            private_zone: "{{ item.1.config.private_zone }}"
           ignore_errors: yes        # In the ansible=4.x versions of route53.py, a failed lookup results in a failure of this route53 module.
           register: r__route53_cname
           with_nested:
             - "{{ hosts_to_clean }}"
-            - "{{ r__route53_info__zones.HostedZones | json_query(\"[?Name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
+            - "{{ r__route53_info__zones.hosted_zones | json_query(\"[?name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
 
         - name: clean/dns/route53 | Remove failed DNS lookups from route53 state=get  (this happens with all the ansible=4.x versions of route53.py)
           set_fact:
@@ -100,7 +100,7 @@
           when: r__route53_cname is failed
 
         - name: clean/dns/route53 | Delete CNAME records
-          route53:
+          amazon.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "absent"
@@ -109,7 +109,7 @@
             type: "{{ item.1.set.type }}"
             ttl: "{{ item.1.set.ttl }}"
             value: ["{{ item.1.set.value }}"]
-            private_zone: "{{ item.1.item.1.Config.PrivateZone }}"
+            private_zone: "{{ item.1.item.1.config.private_zone }}"
           with_nested:
             - "{{ hosts_to_clean }}"
             - "{{ r__route53_cname.results }}"
@@ -120,7 +120,7 @@
     - name: "clean/dns/route53 | Delete DNS entries (new mechanism: route53_zone/ route53_info/ route53)"
       block:
         - name: clean/dns/route53 | Gather info for pre-existing Hosted Zones (public and/or private)
-          route53_info:
+          amazon.aws.route53_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             query: hosted_zone
@@ -129,73 +129,73 @@
         # Note: route53_info currently does not honour the 'max_items' or 'type' fields, (and if 'start_record_name' is not found, it just returns all records), so we need to filter the responses to match 'hosts_to_clean' when doing the delete
         # Note: cannot run route53_info asynchronously as it makes too many concurrent requests and blows the AWS Route53 API limit.
         - name: clean/dns/route53 | Get A records
-          route53_info:
+          amazon.aws.route53_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             type: "A"
             max_items: 1
             query: record_sets
-            hosted_zone_id: "{{ item.1.Id }}"
+            hosted_zone_id: "{{ item.1.id }}"
             start_record_name: "{{item.0.name}}.{{cluster_vars.dns_user_domain}}"
           register: r__route53_info__a
           until: r__route53_info__a is success
           retries: 10
           with_nested:
             - "{{ hosts_to_clean }}"
-            - "{{ r__route53_info__zones.HostedZones | json_query(\"[?Name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
+            - "{{ r__route53_info__zones.hosted_zones | json_query(\"[?name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
 
         - name: clean/dns/route53 | Delete A records
-          route53:
+          amazon.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "absent"
             zone: "{{ cluster_vars.dns_nameserver_zone }}"
-            record: "{{ item.ResourceRecordSets.Name }}"
-            type: "{{ item.ResourceRecordSets.Type }}"
-            ttl: "{{ item.ResourceRecordSets.TTL }}"
-            value: "{{ item.ResourceRecordSets.ResourceRecords | json_query(\"[].Value\") }}"
-            private_zone: "{{ item.PrivateZone }}"
+            record: "{{ item.resource_record_sets.name }}"
+            type: "{{ item.resource_record_sets.type }}"
+            ttl: "{{ item.resource_record_sets.ttl }}"
+            value: "{{ item.resource_record_sets.resource_records | json_query(\"[].value\") }}"
+            private_zone: "{{ item.private_zone }}"
           with_items: "{{ records_to_clean }}"
           vars:
             _fqdns_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)$', '\\1.' + cluster_vars.dns_user_domain + '.') | list }}"
-            records_to_clean: "{{ r__route53_info__a.results | json_query(\"[?ResourceRecordSets[?Type=='A' && contains(\"+ _fqdns_to_clean | string +\", Name)]].{ResourceRecordSets: ResourceRecordSets[?Type=='A']|[0], item0name: item[0].name, PrivateZone: item[1].Config.PrivateZone}\") }}"
+            records_to_clean: "{{ r__route53_info__a.results | json_query(\"[?resource_record_sets[?type=='A' && contains(\"+ _fqdns_to_clean | string +\", Name)]].{resource_record_sets: resource_record_sets[?type=='A']|[0], item0name: item[0].name, private_zone: item[1].config.private_zone}\") }}"
 
         # Note: route53_info currently does not honour the 'max_items' or 'type' fields, (and if 'start_record_name' is not found, it just returns all records), so we need to filter the responses to match 'hosts_to_clean' when doing the delete
         # Note: cannot run route53_info asynchronously as it makes too many concurrent requests and blows the AWS Route53 API limit.
         - name: clean/dns/route53 | Get CNAME records
-          route53_info:
+          amazon.aws.route53_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             type: "CNAME"
             max_items: 1
             query: record_sets
-            hosted_zone_id: "{{ item.1.Id }}"
+            hosted_zone_id: "{{ item.1.id }}"
             start_record_name: "{{item.0.name | regex_replace('-(?!.*-).*')}}.{{cluster_vars.dns_user_domain}}"
           register: r__route53_info__cname
           with_nested:
             - "{{ hosts_to_clean }}"
-            - "{{ r__route53_info__zones.HostedZones | json_query(\"[?Name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
+            - "{{ r__route53_info__zones.hosted_zones | json_query(\"[?name==`\" + cluster_vars.dns_nameserver_zone + \".`]\") }}"
           until: r__route53_info__cname is success
           retries: 10
 
         - name: clean/dns/route53 | Delete CNAME records
-          route53:
+          amazon.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: "absent"
             zone: "{{ cluster_vars.dns_nameserver_zone }}"
-            record: "{{ item.1.ResourceRecordSets.Name }}"
-            type: "{{ item.1.ResourceRecordSets.Type }}"
-            ttl: "{{ item.1.ResourceRecordSets.TTL }}"
-            value: "{{ item.1.ResourceRecordSets.ResourceRecords | json_query(\"[].Value\") }}"
-            private_zone: "{{ item.1.PrivateZone }}"
+            record: "{{ item.1.resource_record_sets.name }}"
+            type: "{{ item.1.resource_record_sets.type }}"
+            ttl: "{{ item.1.resource_record_sets.ttl }}"
+            value: "{{ item.1.resource_record_sets.resource_records | json_query(\"[].value\") }}"
+            private_zone: "{{ item.1.private_zone }}"
           with_nested:
             - "{{ hosts_to_clean }}"
             - "{{ records_to_clean }}"
           vars:
             _fqdns_to_clean: "{{ hosts_to_clean | json_query(\"[].name\") | map('regex_replace', '^(.*)-(?!.*-).*$', '\\1.' + cluster_vars.dns_user_domain + '.') | list }}"   #Remove the last '-.*' (cluster_suffix)
-            records_to_clean: "{{ r__route53_info__cname.results | json_query(\"[?ResourceRecordSets[?Type=='CNAME' && contains(\"+ _fqdns_to_clean | string +\", Name)]].{ResourceRecordSets: ResourceRecordSets[?Type=='CNAME']|[0], item0name: item[0].name, PrivateZone: item[1].Config.PrivateZone}\") }}"
-          when: ((item.0.name | regex_replace('-(?!.*-).*')) == (item.1.ResourceRecordSets.Name | regex_replace('^(.*?)\\..*$', '\\1')))  and  ((item.0.name == item.1.ResourceRecordSets.ResourceRecords[0].Value | regex_replace('^(.*?)\\..*$', '\\1')))
+            records_to_clean: "{{ r__route53_info__cname.results | json_query(\"[?resource_record_sets[?type=='CNAME' && contains(\"+ _fqdns_to_clean | string +\", name)]].{resource_record_sets: resource_record_sets[?type=='CNAME']|[0], item0name: item[0].name, private_zone: item[1].config.private_zone}\") }}"
+          when: ((item.0.name | regex_replace('-(?!.*-).*')) == (item.1.resource_record_sets.name | regex_replace('^(.*?)\\..*$', '\\1')))  and  ((item.0.name == item.1.resource_record_sets.resource_records[0].value | regex_replace('^(.*?)\\..*$', '\\1')))
       when: cluster_vars.dns_server == "route53" and (use_new_route53 is defined and use_new_route53|bool)
 
 
@@ -203,7 +203,7 @@
     - name: clean/dns/clouddns | Delete DNS entries
       block:
         - name: clean/dns/clouddns | Get managed zone(s)
-          gcp_dns_managed_zone_info:
+          google.cloud.gcp_dns_managed_zone_info:
             auth_kind: serviceaccount
             dns_name: "{{cluster_vars.dns_nameserver_zone}}"
             project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
@@ -211,7 +211,7 @@
           register: r__gcp_dns_managed_zone_info
 
         - name: clean/dns/clouddns | Get all non-peered DNS records for managed zones that match cluster_vars.dns_nameserver_zone
-          gcp_dns_resource_record_set_info:
+          google.cloud.gcp_dns_resource_record_set_info:
             auth_kind: serviceaccount
             managed_zone:
               name: "{{item.name}}"
@@ -224,7 +224,7 @@
         - name: clean/dns/clouddns | Delete A and CNAME records
           block:
             - name: clean/dns/clouddns | Delete A records
-              gcp_dns_resource_record_set:
+              google.cloud.gcp_dns_resource_record_set:
                 auth_kind: serviceaccount
                 managed_zone:
                   name: "{{item.1.managed_zone.name}}"
@@ -244,7 +244,7 @@
               when: item.0.name == (item.1.record.name | regex_replace('^(.*?)\\..*$', '\\1'))
 
             - name: clean/dns/clouddns | Delete CNAME records
-              gcp_dns_resource_record_set:
+              google.cloud.gcp_dns_resource_record_set:
                 auth_kind: serviceaccount
                 managed_zone:
                   name: "{{item.1.managed_zone.name}}"

--- a/clean/tasks/gcp.yml
+++ b/clean/tasks/gcp.yml
@@ -3,7 +3,7 @@
 - name: clean/gcp | clean vms
   block:
     - name: clean/gcp | Remove deletion protection
-      gcp_compute_instance:
+      google.cloud.gcp_compute_instance:
         name: "{{item.name}}"
         project: "{{cluster_vars[buildenv].vpc_project_id}}"
         zone: "{{ item.regionzone }}"
@@ -14,7 +14,7 @@
       when: cluster_vars[buildenv].deletion_protection | bool
 
     - name: clean/gcp | Delete VMs
-      gcp_compute_instance:
+      google.cloud.gcp_compute_instance:
         name: "{{item.name}}"
         project: "{{cluster_vars[buildenv].vpc_project_id}}"
         zone: "{{ item.regionzone }}"
@@ -35,7 +35,7 @@
       with_items: "{{r__gcp_compute_instance.results}}"
 
     - name: clean/gcp | Get any attached static IPs
-      gcp_compute_address_info:
+      google.cloud.gcp_compute_address_info:
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         project: "{{cluster_vars[buildenv].vpc_project_id}}"
@@ -49,7 +49,7 @@
       debug: msg={{ r__gcp_compute_address_info }}
 
     - name: clean/gcp | Delete static IPs (if any were found)
-      gcp_compute_address:
+      google.cloud.gcp_compute_address:
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         project: "{{cluster_vars[buildenv].vpc_project_id}}"
@@ -63,7 +63,7 @@
 - name: clean/gcp | clean networking (when '-e clean=_all_')
   block:
     - name: clean/networking/gcp | Delete GCP cluster firewalls
-      gcp_compute_firewall:
+      google.cloud.gcp_compute_firewall:
         name: "{{ item.name }}"
         state: "absent"
         auth_kind: "serviceaccount"
@@ -72,7 +72,7 @@
       with_items: "{{ cluster_vars.firewall_rules }}"
 
     - name: clean/gcp | Delete the GCP network (if -e delete_gcp_network=true)
-      gcp_compute_network:
+      google.cloud.gcp_compute_network:
         name: "{{cluster_vars[buildenv].vpc_network_name}}"
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"

--- a/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_aws.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: get_cluster_hosts_state/aws | Get existing instance info
-  ec2_instance_info:
+  amazon.aws.ec2_instance_info:
     filters:
       "tag:cluster_name": "{{cluster_name}}"
       "instance-state-name": ["running", "pending", "stopped"]

--- a/cluster_hosts/tasks/get_cluster_hosts_state_gcp.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_state_gcp.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: get_cluster_hosts_state/gcp | Get existing instance info (per AZ)
-  gcp_compute_instance_info:
+  google.cloud.gcp_compute_instance_info:
     zone: "{{cluster_vars.region}}-{{item}}"
     filters: [ "labels.cluster_name = {{cluster_name}}" ]
     project: "{{cluster_vars[buildenv].vpc_project_id}}"
@@ -14,7 +14,7 @@
   run_once: true
 
 - name: get_cluster_hosts_state/gcp | Get root volume info (for image)
-  gcp_compute_disk_info:
+  google.cloud.gcp_compute_disk_info:
     zone: "{{item.zone | basename }}"
     filters: [ "name = {{ item.bootdisk }}" ]
     project: "{{cluster_vars[buildenv].vpc_project_id}}"

--- a/cluster_hosts/tasks/get_cluster_hosts_target.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target.yml
@@ -48,8 +48,9 @@
 
 
 - name: get_cluster_hosts_target | Augment with cloud-specific parameters (if necessary)
-  include: "{{ item }}"
+  include_tasks: "{{ item__include_tasks }}"
   loop: "{{ query('first_found', params) }}"
+  loop_control: { loop_var: item__include_tasks }   #This mechanism to include_tasks only when the file exists, also creates a loop iterator 'item' that it sends to the included tasks.  If they also have loops, we get "The loop variable 'item' is already in use" warning.
   vars: { params: { files: ["get_cluster_hosts_target_{{cluster_vars.type}}.yml"], skip: true } }
 
 

--- a/cluster_hosts/tasks/get_cluster_hosts_target_aws.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target_aws.yml
@@ -2,7 +2,7 @@
 
 # Dynamically look up VPC ID by name from aws
 - name: get_cluster_hosts_target/aws | Looking up VPC facts to extract ID
-  ec2_vpc_net_info:
+  amazon.aws.ec2_vpc_net_info:
     region: "{{ cluster_vars.region }}"
     aws_access_key: "{{ cluster_vars[buildenv].aws_access_key }}"
     aws_secret_key: "{{ cluster_vars[buildenv].aws_secret_key }}"
@@ -20,7 +20,7 @@
 - name: get_cluster_hosts_target/aws | Add subnet ids to cluster_hosts_target
   block:
     - name: get_cluster_hosts_target/aws | Look up proxy subnet facts
-      ec2_vpc_subnet_info:
+      amazon.aws.ec2_vpc_subnet_info:
         region: "{{ cluster_vars.region }}"
         aws_access_key: "{{ cluster_vars[buildenv].aws_access_key }}"
         aws_secret_key: "{{ cluster_vars[buildenv].aws_secret_key }}"
@@ -43,7 +43,7 @@
 - name: get_cluster_hosts_target/aws | Add snapshot info (if found) to cluster_hosts_target
   block:
     - name: get_cluster_hosts_target/aws | Get snapshots info
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{ cluster_vars.region }}"
@@ -86,7 +86,7 @@
 - name: get_cluster_hosts_target/aws | cluster_vars.image can either be an AMI in its own right, or a 'manifest-location' filter to the latest AMI.
   block:
     - name: get_cluster_hosts_target/aws | Attempt to evaluate the image as an AMI
-      ec2_ami_info:
+      amazon.aws.ec2_ami_info:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"
@@ -104,7 +104,7 @@
           delegate_to: localhost
           run_once: true
           
-        - name: get_cluster_hosts_target/aws | Search the instance type info for the flavor of each hosttype's ami (to get architecture, needed for ec2_ami_info)
+        - name: get_cluster_hosts_target/aws | Search the instance type info for the flavor of each hosttype's ami (to get architecture, needed for amazon.aws.ec2_ami_info)
           ec2_instance_type_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
@@ -115,7 +115,7 @@
           run_once: true
 
         - name: get_cluster_hosts_target/aws | Get the AMI per hosttype and filtered on 'manifest-location'
-          ec2_ami_info:
+          amazon.aws.ec2_ami_info:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             region: "{{cluster_vars.region}}"

--- a/cluster_hosts/tasks/get_cluster_hosts_target_gcp.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target_gcp.yml
@@ -20,7 +20,7 @@
 - name: get_cluster_hosts_target/gcp | cluster_vars.image can either be an AMI in its own right, or a filter to the latest AMI.
   block:
     - name: get_cluster_hosts_target/gcp | Find the image as either an discrete image or a filter
-      gcp_compute_image_info:
+      google.cloud.gcp_compute_image_info:
         filters: [ "name = {{_image.name}}" ]
         project: "{{_image.project}}"
         auth_kind: "serviceaccount"

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -2,7 +2,7 @@
 
 - block:
     - name: config/dns/a/nsupdate | create/update A records in bind (nsupdate)
-      nsupdate:
+      community.general.nsupdate:
         key_name: "{{cluster_vars[buildenv].nsupdate_cfg.key_name | default(bind9[buildenv].key_name)}}"
         key_secret: "{{cluster_vars[buildenv].nsupdate_cfg.key_secret | default(bind9[buildenv].key_secret)}}"
         server: "{{cluster_vars[buildenv].nsupdate_cfg.server | default(bind9[buildenv].server)}}"
@@ -22,7 +22,7 @@
 
 - block:
     - name: config/dns/a/route53 | Gather info for pre-existing Hosted Zones (public and/or private)
-      route53_info:
+      amazon.aws.route53_info:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         query: hosted_zone
@@ -31,7 +31,7 @@
       register: r__route53_info__zones
 
     - name: config/dns/a/route53 | create/update A records for all matching zones, (public and/or private) in AWS (route53)
-      route53:
+      amazon.aws.route53:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         state: present
@@ -49,11 +49,11 @@
       with_items: |
         {% set res = [] -%}
         {%- for cht_host in cluster_hosts_target -%}
-          {%- for hosted_zone in r__route53_info__zones.HostedZones | default([]) | json_query('[?Name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
-            {%- if hosted_zone.Config.PrivateZone|bool == true and 'ipv4_private' in hostvars[cht_host.hostname] -%}
-              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.Config.PrivateZone, 'ipv4': hostvars[cht_host.hostname]['ipv4_private']}) -%}
-            {%- elif hosted_zone.Config.PrivateZone|bool == false and 'ipv4_public' in hostvars[cht_host.hostname] -%} 
-              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.Config.PrivateZone, 'ipv4': hostvars[cht_host.hostname]['ipv4_public']}) -%}
+          {%- for hosted_zone in r__route53_info__zones.hosted_zones | default([]) | json_query('[?name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
+            {%- if hosted_zone.config.private_zone|bool == true and 'ipv4_private' in hostvars[cht_host.hostname] -%}
+              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.config.private_zone, 'ipv4': hostvars[cht_host.hostname]['ipv4_private']}) -%}
+            {%- elif hosted_zone.config.private_zone|bool == false and 'ipv4_public' in hostvars[cht_host.hostname] -%} 
+              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.config.private_zone, 'ipv4': hostvars[cht_host.hostname]['ipv4_public']}) -%}
             {%- endif -%}
           {%- endfor -%}
         {%- endfor -%}
@@ -76,10 +76,10 @@
           delegate_to: localhost
 
       # rescue A-record creation in AWS (route53) to cope with the error below (this is most frequent when creating 15+ nodes clusters)
-      # "Timeout waiting for resource records changes to be applied: Waiter ResourceRecordSetsChanged failed: Rate exceeded"
+      # "Timeout waiting for resource records changes to be applied: Waiter resource_record_setsChanged failed: Rate exceeded"
       rescue:
         - name: config/dns/a/route53 | Resubmit A records in AWS (route53) which failed the previous step
-          route53:
+          amazon.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: present
@@ -100,7 +100,7 @@
 - name: config/dns/a/clouddns | create/update A records in GCP (clouddns)
   block:
     - name: config/dns/a/clouddns | Gather info for pre-existing Managed Zones (public and/or private)
-      gcp_dns_managed_zone_info:
+      google.cloud.gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
         dns_name: "{{cluster_vars.dns_nameserver_zone}}"
         project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
@@ -111,7 +111,7 @@
       run_once: true
 
     - name: config/dns/a/clouddns | create/update A records for all matching zones, (public and/or private) in GCP (clouddns)
-      gcp_dns_resource_record_set:
+      google.cloud.gcp_dns_resource_record_set:
         auth_kind: serviceaccount
         managed_zone:
           name: "{{item.1.name}}"

--- a/config/tasks/create_dns_a.yml
+++ b/config/tasks/create_dns_a.yml
@@ -22,7 +22,7 @@
 
 - block:
     - name: config/dns/a/route53 | Gather info for pre-existing Hosted Zones (public and/or private)
-      amazon.aws.route53_info:
+      community.aws.route53_info:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         query: hosted_zone
@@ -31,7 +31,7 @@
       register: r__route53_info__zones
 
     - name: config/dns/a/route53 | create/update A records for all matching zones, (public and/or private) in AWS (route53)
-      amazon.aws.route53:
+      community.aws.route53:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         state: present
@@ -49,11 +49,11 @@
       with_items: |
         {% set res = [] -%}
         {%- for cht_host in cluster_hosts_target -%}
-          {%- for hosted_zone in r__route53_info__zones.hosted_zones | default([]) | json_query('[?name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
-            {%- if hosted_zone.config.private_zone|bool == true and 'ipv4_private' in hostvars[cht_host.hostname] -%}
-              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.config.private_zone, 'ipv4': hostvars[cht_host.hostname]['ipv4_private']}) -%}
-            {%- elif hosted_zone.config.private_zone|bool == false and 'ipv4_public' in hostvars[cht_host.hostname] -%} 
-              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.config.private_zone, 'ipv4': hostvars[cht_host.hostname]['ipv4_public']}) -%}
+          {%- for hosted_zone in r__route53_info__zones.HostedZones | default([]) | json_query('[?Name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
+            {%- if hosted_zone.Config.PrivateZone|bool == true and 'ipv4_private' in hostvars[cht_host.hostname] -%}
+              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.Config.PrivateZone, 'ipv4': hostvars[cht_host.hostname]['ipv4_private']}) -%}
+            {%- elif hosted_zone.Config.PrivateZone|bool == false and 'ipv4_public' in hostvars[cht_host.hostname] -%} 
+              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.Config.PrivateZone, 'ipv4': hostvars[cht_host.hostname]['ipv4_public']}) -%}
             {%- endif -%}
           {%- endfor -%}
         {%- endfor -%}
@@ -79,7 +79,7 @@
       # "Timeout waiting for resource records changes to be applied: Waiter resource_record_setsChanged failed: Rate exceeded"
       rescue:
         - name: config/dns/a/route53 | Resubmit A records in AWS (route53) which failed the previous step
-          amazon.aws.route53:
+          community.aws.route53:
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
             state: present

--- a/config/tasks/disks_auto_cloud.yml
+++ b/config/tasks/disks_auto_cloud.yml
@@ -19,7 +19,7 @@
 
     - name: disks_auto_cloud | Create filesystem (partitionless)
       become: yes
-      filesystem:
+      community.general.filesystem:
         fstype: "{{ item.fstype }}"
         dev: "{{ _dev }}"
       loop: "{{auto_vols}}"
@@ -38,7 +38,7 @@
 
     - name: disks_auto_cloud | Mount created filesytem(s) persistently
       become: yes
-      mount:
+      ansible.posix.mount:
         path: "{{ item.mountpoint }}"
         src: "UUID={{ _UUID }}"
         fstype: "{{ item.fstype }}"
@@ -126,20 +126,20 @@
 
         - name: disks_auto_cloud/lvm | Create a volume group from all block devices
           become: yes
-          lvg:
+          community.general.lvg:
             vg: "{{ lvmparams.vg_name }}"
             pvs: "{{ raid_vols_devices | map(attribute='device_name_os') | sort | join(',') }}"
 
         - name: disks_auto_cloud/lvm | Create a logical volume from volume group
           become: yes
-          lvol:
+          community.general.lvol:
             vg: "{{ lvmparams.vg_name }}"
             lv: "{{ lvmparams.lv_name }}"
             size: "{{ lvmparams.lv_size }}"
 
         - name: disks_auto_cloud/lvm | Create filesystem(s) on attached volume(s)
           become: yes
-          filesystem:
+          community.general.filesystem:
             fstype: "{{ raid_vols[0].fstype }}"
             dev: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
             force: no       # This doesn't appear to prevent the '-F' option being sent to mkfs
@@ -147,7 +147,7 @@
 
         - name: disks_auto_cloud/lvm | Mount created filesytem(s) persistently
           become: yes
-          mount:
+          ansible.posix.mount:
             path: "{{ raid_vols[0].mountpoint }}"
             src: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
             fstype: "{{ raid_vols[0].fstype }}"

--- a/config/tasks/disks_auto_generic.yml
+++ b/config/tasks/disks_auto_generic.yml
@@ -35,7 +35,7 @@
     # Create partition-less filesystems.
     - name: disks_auto_generic | Create filesystem(s) on attached volume(s)
       become: yes
-      filesystem:
+      community.general.filesystem:
         fstype: "{{ item.fstype }}"
         dev: "{{ item.device }}"
         force: no
@@ -43,7 +43,7 @@
 
     - name: disks_auto_generic | Mount created filesytem(s) persistently
       become: yes
-      mount:
+      ansible.posix.mount:
         path: "{{ item.mountpoint }}"
         src: "{{ item.device }}"
         fstype: "{{ item.fstype }}"
@@ -85,27 +85,27 @@
 
         - name: disks_auto_generic/lvm | Create a volume group from all block devices
           become: yes
-          lvg:
+          community.general.lvg:
             vg: "{{ lvmparams.vg_name }}"
             pvs: "{{ raid_vols_devices | sort | join(',') }}"
 
         - name: disks_auto_generic/lvm | Create a logical volume from volume group
           become: yes
-          lvol:
+          community.general.lvol:
             vg: "{{ lvmparams.vg_name }}"
             lv: "{{ lvmparams.lv_name }}"
             size: "{{ lvmparams.lv_size }}"
 
         - name: disks_auto_generic/lvm | Create filesystem(s) on attached volume(s)
           become: yes
-          filesystem:
+          community.general.filesystem:
             fstype: "{{ disks_auto_generic__hostvols[0].fstype }}"
             dev: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
             force: no
 
         - name: disks_auto_generic/lvm | Mount created filesytem(s) persistently
           become: yes
-          mount:
+          ansible.posix.mount:
             path: "{{ disks_auto_generic__hostvols[0].mountpoint }}"
             src: "/dev/{{ lvmparams.vg_name }}/{{ lvmparams.lv_name }}"
             fstype: "{{ disks_auto_generic__hostvols[0].fstype }}"

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -27,8 +27,9 @@
   when: ansible_os_family == 'Debian'
 
 - name: Run cloud-specific config (if defined)
-  include: "{{ item }}"
+  include_tasks: "{{ item__include_tasks }}"
   loop: "{{ query('first_found', params) }}"
+  loop_control: { loop_var: item__include_tasks }   #This mechanism to include_tasks only when the file exists, also creates a loop iterator 'item' that it sends to the included tasks.  If they also have loops, we get "The loop variable 'item' is already in use" warning.
   vars: { params: { files: ["config_{{cluster_vars.type}}.yml"], skip: true } }
 
 - name: Disable requiretty in sudoers to enable pipelining

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -4,7 +4,7 @@
   debug: msg="{{cluster_hosts_target_denormalised_by_volume}}"
 
 - name: create/aws | Create security groups
-  ec2_group:
+  amazon.aws.ec2_security_group:
     name: "{{ cluster_name }}-sg"
     description: "{{ cluster_name }} rules"
     region: "{{cluster_vars.region}}"
@@ -24,7 +24,7 @@
 - name: create/aws | Create EC2 VMs asynchronously and wait for completion
   block:
     - name: create/aws | Detach volumes from previous instances (during the _scheme_rmvm_keepdisk_rollback redeploy, we only redeploy one host at a time, and it is already powered off)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"
@@ -108,12 +108,17 @@
         tasks_from: "get_cluster_hosts_state_{{cluster_vars.type}}.yml"
 
     - name: create/aws | If (cluster_vars.assign_public_ip in [true, 'static']) then associate a new elastic IP with each instance
-      ec2_eip:
+      amazon.aws.ec2_eip:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"
         device_id: "{{ item.instance_id }}"
         release_on_disassociation: yes
+        tags:
+          Name: "{{ item.hostname }}"
+          cluster_name: "{{cluster_name}}"
+          cluster_suffix: "{{cluster_suffix}}"
+          owner: "{{ lookup('env','USER') | lower }}"
       loop: "{{ cluster_hosts_state }}"
       when: "'assign_public_ip' in cluster_vars and cluster_vars.assign_public_ip in [true, 'static']"
 
@@ -122,7 +127,7 @@
         cluster_hosts_created: "{{ r__async_status__ec2.results | json_query(\"[?changed==`true`].item.item\") }}"
 
     - name: create/aws | Attach (or create) volumes where 'src' is present (e.g. inserted as part of _scheme_rmvm_keepdisk_rollback scheme)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"
@@ -152,7 +157,7 @@
 #      debug: msg={{r__async_status__ec2_vol}}
 
     - name: create/aws | Set the ec2 volume name tag
-      ec2_tag:
+      amazon.aws.ec2_tag:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -4,7 +4,7 @@
   debug: msg="{{cluster_hosts_target_denormalised_by_volume}}"
 
 - name: create/aws | Create security groups
-  amazon.aws.ec2_security_group:
+  amazon.aws.ec2_group:
     name: "{{ cluster_name }}-sg"
     description: "{{ cluster_name }} rules"
     region: "{{cluster_vars.region}}"
@@ -108,7 +108,7 @@
         tasks_from: "get_cluster_hosts_state_{{cluster_vars.type}}.yml"
 
     - name: create/aws | If (cluster_vars.assign_public_ip in [true, 'static']) then associate a new elastic IP with each instance
-      amazon.aws.ec2_eip:
+      community.aws.ec2_eip:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"

--- a/create/tasks/create_gcp.yml
+++ b/create/tasks/create_gcp.yml
@@ -3,7 +3,7 @@
 - name: create/gcp | Create network and subnetwork (if -e create_gcp_network=true)
   block:
     - name: create/gcp | Create host network (if -e create_gcp_network=true)
-      gcp_compute_network:
+      google.cloud.gcp_compute_network:
         name: "{{cluster_vars[buildenv].vpc_network_name}}"
         auto_create_subnetworks: "{%- if cluster_vars[buildenv].vpc_subnet_name is defined and cluster_vars[buildenv].vpc_subnet_name != '' -%} false {%- else -%} true {%- endif -%}"
         project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
@@ -12,7 +12,7 @@
       register: r__gcp_compute_network
 
     - name: create/gcp | Create host subnetwork (if -e create_gcp_network=true)
-      gcp_compute_subnetwork:
+      google.cloud.gcp_compute_subnetwork:
         name: "{{cluster_vars[buildenv].vpc_subnet_name}}"
         network: "{{r__gcp_compute_network}}"
         project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
@@ -25,7 +25,7 @@
 - name: create/gcp | Create firewalls
   block:
     - name: create/gcp | Get network facts
-      gcp_compute_network_info:
+      google.cloud.gcp_compute_network_info:
         filters:
           - "name = {{cluster_vars[buildenv].vpc_network_name}}"
         project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
@@ -38,7 +38,7 @@
       assert: { that: "r__gcp_compute_network_info['resources'] | length > 0", msg: "The {{cluster_vars[buildenv].vpc_network_name}} network must exist (create with ' -e create_gcp_network=true')" }
 
     - name: create/gcp | Get subnetwork facts
-      gcp_compute_subnetwork_info:
+      google.cloud.gcp_compute_subnetwork_info:
         filters:
           - "name = {{cluster_vars[buildenv].vpc_subnet_name}}"
         project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
@@ -54,7 +54,7 @@
       when: (cluster_vars[buildenv].vpc_subnet_name is defined) and (cluster_vars[buildenv].vpc_subnet_name != "")
 
     - name: create/gcp | Create cluster firewalls
-      gcp_compute_firewall:
+      google.cloud.gcp_compute_firewall:
         name: "{{ item.name }}"
         target_tags: "{{cluster_vars.network_fw_tags}}"
         allowed: "{{ item.allowed }}"
@@ -71,7 +71,7 @@
 - name: create/gcp | Create VMs asynchronously and wait for completion
   block:
     - name: create/gcp | Detach volumes from previous instances (during the _scheme_rmvm_keepdisk_rollback redeploy, we only redeploy one host at a time, and it is already powered off)
-      gce_pd:
+      community.google.gce_pd:
         credentials_file: "{{gcp_credentials_file}}"
         service_account_email: "{{ (lookup('file', gcp_credentials_file) | from_json).client_email }}"
         project_id: "{{cluster_vars[buildenv].vpc_project_id}}"
@@ -83,7 +83,7 @@
       loop: "{{ cluster_hosts_target_denormalised_by_volume | selectattr('auto_volume.src', 'defined') | list }}"
 
     - name: create/gcp | If (cluster_vars.assign_public_ip in [true, 'static']) then create a new static IP for each instance
-      gcp_compute_address:
+      google.cloud.gcp_compute_address:
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         project: "{{cluster_vars[buildenv].vpc_project_id}}"
@@ -98,7 +98,7 @@
       debug: msg={{r__gcp_compute_address}}
 
     - name: create/gcp | Create VMs asynchronously
-      gcp_compute_instance:
+      google.cloud.gcp_compute_instance:
         auth_kind: "serviceaccount"
         service_account_file: "{{gcp_credentials_file}}"
         project: "{{cluster_vars[buildenv].vpc_project_id}}"
@@ -161,7 +161,7 @@
         cluster_hosts_created: "{{ r__async_status__gcp_compute_instance.results | json_query(\"[?item.changed==`true`].item.item\") }}"
 
     - name: create/gcp | Label the volumes
-      gce_labels:
+      community.google.gce_labels:
         project_id: "{{cluster_vars[buildenv].vpc_project_id}}"
         credentials_file: "{{gcp_credentials_file}}"
         resource_url: "{{item.resource_url}}"
@@ -184,7 +184,7 @@
           release: "{{ release_version }}"
 
 #    - name: create/gcp | Attach (or create) volumes where 'src' is present (e.g. inserted as part of _scheme_rmvm_keepdisk_rollback scheme)
-#      gce_pd:
+#      community.google.gce_pd:
 #        credentials_file: "{{gcp_credentials_file}}"
 #        service_account_email: "{{ (lookup('file', gcp_credentials_file) | from_json).client_email }}"
 #        project_id: "{{cluster_vars[buildenv].vpc_project_id}}"
@@ -209,7 +209,7 @@
 #      with_items: "{{r__gce_pd.results}}"
 #
 #    - name: create/gcp | Get existing GCE instance info (per AZ)
-#      gcp_compute_instance_info:
+#      google.cloud.gcp_compute_instance_info:
 #        zone: "{{cluster_vars.region}}-{{item}}"
 #        filters:
 #          - "labels.cluster_name = {{cluster_name}}"
@@ -225,7 +225,7 @@
 #      debug: msg={{r__gcp_compute_instance_info.results}}
 #
 #    - name: create/gcp | Label the volumes
-#      gce_labels:
+#      community.google.gce_labels:
 #        project_id: "{{cluster_vars[buildenv].vpc_project_id}}"
 #        credentials_file: "{{gcp_credentials_file}}"
 #        resource_url: "{{item.resource_url}}"

--- a/dynamic_inventory/tasks/main.yml
+++ b/dynamic_inventory/tasks/main.yml
@@ -31,9 +31,9 @@
     ansible_ssh_private_key_file: "{{ cluster_vars[buildenv].ssh_connection_cfg.host.ansible_ssh_private_key_file | default(None) | ternary('id_rsa_ansible_ssh_private_key_file', omit) }}"
   with_items: "{{ cluster_hosts_state | json_query(\"[?contains(['RUNNING','running','poweredOn'], instance_state)]\") }}"
   vars:
-    _local_cidr: "{{ (ansible_default_ipv4.network+'/'+ansible_default_ipv4.netmask) | ipaddr('network/prefix') }}"                                 # Get the network the localhost IP is in
+    _local_cidr: "{{ (ansible_default_ipv4.network+'/'+ansible_default_ipv4.netmask) | ansible.utils.ipaddr('network/prefix') }}"                                 # Get the network the localhost IP is in
     _bastion_host: "{{ cluster_vars[buildenv].ssh_connection_cfg.bastion.ssh_args | default() | regex_replace('.*@([]\\w\\d\\.-]*).*', '\\1') }}"   # Extract just the bastion hostname from 'cluster_vars[buildenv].ssh_connection_cfg.bastion.ssh_args'
-    _bastion_in_host_net: "{{ query('dig', _bastion_host, errors='ignore') | map('ipaddr', _local_cidr) | select() | list | length > 0 }}"          # Check each bastion IP (there could be multiple results from the 'dig'), and see they're in the _local_cidr range.
+    _bastion_in_host_net: "{{ query('dig', _bastion_host, errors='ignore') | map('ansible.utils.ipaddr', _local_cidr) | select() | list | length > 0 }}"          # Check each bastion IP (there could be multiple results from the 'dig'), and see they're in the _local_cidr range.
 
 
 - name: dynamic_inventory | stat the inventory_file path

--- a/readiness/tasks/config_dns_cname.yml
+++ b/readiness/tasks/config_dns_cname.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: create/dns/cname/nsupdate | create/update CNAME records in bind (nsupdate)
-  nsupdate:
+  community.general.nsupdate:
     key_name: "{{cluster_vars[buildenv].nsupdate_cfg.key_name | default(bind9[buildenv].key_name)}}"
     key_secret: "{{cluster_vars[buildenv].nsupdate_cfg.key_secret | default(bind9[buildenv].key_secret)}}"
     server: "{{cluster_vars[buildenv].nsupdate_cfg.server | default(bind9[buildenv].server)}}"
@@ -19,7 +19,7 @@
 - name: create/dns/cname/route53 | create/update CNAME records in AWS (route53)
   block:
     - name: config/dns/cname/route53 | Gather info for pre-existing Hosted Zones (public and/or private)
-      route53_info:
+      amazon.aws.route53_info:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         query: hosted_zone
@@ -28,7 +28,7 @@
       register: r__route53_info__zones
 
     - name: config/dns/cname/route53 | create/update CNAME records for all matching zones, (public and/or private) in AWS (route53)
-      route53:
+      amazon.aws.route53:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         state: present
@@ -42,9 +42,9 @@
       with_items: |
         {% set res = [] -%}
         {%- for cht_host in cluster_hosts_target -%}
-          {%- for hosted_zone in r__route53_info__zones.HostedZones | default([]) | json_query('[?Name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
-            {%- if hosted_zone.Config.PrivateZone|bool == true and 'ipv4_private' in hostvars[cht_host.hostname]  or  hosted_zone.Config.PrivateZone|bool == false and 'ipv4_public' in hostvars[cht_host.hostname] -%} 
-              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.Config.PrivateZone}) -%}
+          {%- for hosted_zone in r__route53_info__zones.hosted_zones | default([]) | json_query('[?name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
+            {%- if hosted_zone.config.private_zone|bool == true and 'ipv4_private' in hostvars[cht_host.hostname]  or  hosted_zone.config.private_zone|bool == false and 'ipv4_public' in hostvars[cht_host.hostname] -%} 
+              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.config.private_zone}) -%}
             {%- endif -%}
           {%- endfor -%}
         {%- endfor -%}
@@ -72,7 +72,7 @@
 - name: config/dns/cname/clouddns | create/update CNAME records in clouddns
   block:
     - name: config/dns/cname/clouddns | Gather info for a pre-existing GCP Managed Zone and store as dict
-      gcp_dns_managed_zone_info:
+      google.cloud.gcp_dns_managed_zone_info:
         auth_kind: serviceaccount
         dns_name: "{{cluster_vars.dns_nameserver_zone}}"
         project: "{{cluster_vars[buildenv].vpc_host_project_id}}"
@@ -83,7 +83,7 @@
       run_once: true
 
     - name: config/dns/cname/clouddns | create/update CNAME records in GCP (clouddns)
-      gcp_dns_resource_record_set:
+      google.cloud.gcp_dns_resource_record_set:
         auth_kind: serviceaccount
         managed_zone:
           name: "{{item.1.name}}"

--- a/readiness/tasks/config_dns_cname.yml
+++ b/readiness/tasks/config_dns_cname.yml
@@ -19,7 +19,7 @@
 - name: create/dns/cname/route53 | create/update CNAME records in AWS (route53)
   block:
     - name: config/dns/cname/route53 | Gather info for pre-existing Hosted Zones (public and/or private)
-      amazon.aws.route53_info:
+      community.aws.route53_info:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         query: hosted_zone
@@ -28,7 +28,7 @@
       register: r__route53_info__zones
 
     - name: config/dns/cname/route53 | create/update CNAME records for all matching zones, (public and/or private) in AWS (route53)
-      amazon.aws.route53:
+      community.aws.route53:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         state: present
@@ -42,9 +42,9 @@
       with_items: |
         {% set res = [] -%}
         {%- for cht_host in cluster_hosts_target -%}
-          {%- for hosted_zone in r__route53_info__zones.hosted_zones | default([]) | json_query('[?name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
-            {%- if hosted_zone.config.private_zone|bool == true and 'ipv4_private' in hostvars[cht_host.hostname]  or  hosted_zone.config.private_zone|bool == false and 'ipv4_public' in hostvars[cht_host.hostname] -%} 
-              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.config.private_zone}) -%}
+          {%- for hosted_zone in r__route53_info__zones.HostedZones | default([]) | json_query('[?Name==`' + cluster_vars.dns_nameserver_zone + '.`]') -%}
+            {%- if hosted_zone.Config.PrivateZone|bool == true and 'ipv4_private' in hostvars[cht_host.hostname]  or  hosted_zone.Config.PrivateZone|bool == false and 'ipv4_public' in hostvars[cht_host.hostname] -%} 
+              {%- set _ = res.append({'hostname': cht_host.hostname, 'private_zone': hosted_zone.Config.PrivateZone}) -%}
             {%- endif -%}
           {%- endfor -%}
         {%- endfor -%}

--- a/readiness/tasks/main.yml
+++ b/readiness/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
 
 - name: readiness | Remove maintenance mode
-  include_tasks: "{{ item }}"
+  include_tasks: "{{ item__include_tasks }}"
   loop: "{{ query('first_found', params) }}"
+  loop_control: { loop_var: item__include_tasks }   #This mechanism to include_tasks only when the file exists, also creates a loop iterator 'item' that it sends to the included tasks.  If they also have loops, we get "The loop variable 'item' is already in use" warning.
   vars: { params: { files: ["remove_maintenance_mode_{{cluster_vars.type}}.yml"], skip: true } }
 
 - name: readiness | create/update DNS CNAME records

--- a/readiness/tasks/remove_maintenance_mode_aws.yml
+++ b/readiness/tasks/remove_maintenance_mode_aws.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: remove_maintenance_mode/aws | Set maintenance_mode to false
-  ec2_tag:
+  amazon.aws.ec2_tag:
     aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
     aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
     region: "{{cluster_vars.region}}"

--- a/readiness/tasks/remove_maintenance_mode_gcp.yml
+++ b/readiness/tasks/remove_maintenance_mode_gcp.yml
@@ -2,7 +2,7 @@
 
 # Use this because the gce_labels command does not replace existing labels.  https://github.com/ansible/ansible/pull/59891
 - name: remove_maintenance_mode/gcp | Set maintenance_mode=false asynchronously
-  gcp_compute_instance:
+  google.cloud.gcp_compute_instance:
     name: "{{item.name}}"
     project: "{{cluster_vars[buildenv].vpc_project_id}}"
     zone: "{{ item.regionzone | basename }}"

--- a/redeploy/__common/tasks/powerchange_vms_aws.yml
+++ b/redeploy/__common/tasks/powerchange_vms_aws.yml
@@ -6,7 +6,7 @@
 - name: "powerchange_vms/aws | {{powerchange_new_state}} VM(s) and set maintenance_mode=true (if stopping)"
   block:
     - name: powerchange_vms/aws | Set maintenance_mode=true (if stopping)
-      ec2_tag:
+      amazon.aws.ec2_tag:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{cluster_vars.region}}"
@@ -16,7 +16,7 @@
       when: "powerchange_new_state == 'stop'"
 
     - name: "powerchange_vms/aws | {{powerchange_new_state}} VMs"
-      ec2_instance:
+      amazon.aws.ec2_instance:
         aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         region: "{{ cluster_vars.region }}"

--- a/redeploy/__common/tasks/powerchange_vms_gcp.yml
+++ b/redeploy/__common/tasks/powerchange_vms_gcp.yml
@@ -6,7 +6,7 @@
 - name: "powerchange_vms/gcp | {{powerchange_new_state}} VM(s) and set maintenance_mode=true"
   block:
     - name: "powerchange_vms/gcp | {{powerchange_new_state}} VMs asynchronously and set maintenance_mode=true (if stopping)"
-      gcp_compute_instance:
+      google.cloud.gcp_compute_instance:
         name: "{{item.name}}"
         project: "{{cluster_vars[buildenv].vpc_project_id}}"
         zone: "{{ item.regionzone }}"

--- a/redeploy/__common/tasks/set_lifecycle_state_label_aws.yml
+++ b/redeploy/__common/tasks/set_lifecycle_state_label_aws.yml
@@ -4,7 +4,7 @@
   debug: msg="{{hosts_to_relabel}}"
 
 - name: "set_lifecycle_state_label/aws | Change lifecycle_state label to {{new_state}}"
-  ec2_tag:
+  amazon.aws.ec2_tag:
     aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
     aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
     region: "{{cluster_vars.region}}"

--- a/redeploy/__common/tasks/set_lifecycle_state_label_gcp.yml
+++ b/redeploy/__common/tasks/set_lifecycle_state_label_gcp.yml
@@ -4,7 +4,7 @@
   debug: msg="{{hosts_to_relabel}}"
 
 - name: "set_lifecycle_state_label/gcp | Change lifecycle_state label to {{new_state}}"
-  gcp_compute_instance:
+  google.cloud.gcp_compute_instance:
     name: "{{item.name}}"
     project: "{{cluster_vars[buildenv].vpc_project_id}}"
     zone: "{{ item.regionzone }}"

--- a/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
+++ b/redeploy/_scheme_rmvm_keepdisk_rollback/tasks/preflight.yml
@@ -4,7 +4,7 @@
   block:
     - block:
         - name: Preflight check | get ec2_instance_info for current disk information
-          ec2_instance_info:
+          amazon.aws.ec2_instance_info:
             filters: { "instance-state-name": [ "running", "pending", "stopped" ], "tag:cluster_name": "{{cluster_name}}", "tag:lifecycle_state": "current" }
             aws_access_key: "{{cluster_vars[buildenv].aws_access_key}}"
             aws_secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"


### PR DESCRIPTION
Remove deprecation warnings and other warnings. Replace non-builtin commands with FQCNs for future compatibility, whilst retaining compatibility with Ansible 5.6.0 (some community.aws -> amazon.aws replacements are only valid with Amazon>=7)