### PR TITLE
Fix deleting DNS in the _scheme_rmvm_rmdisk_only redeploy scheme

### DIFF
--- a/redeploy/_scheme_rmvm_rmdisk_only/tasks/by_hosttype_by_host.yml
+++ b/redeploy/_scheme_rmvm_rmdisk_only/tasks/by_hosttype_by_host.yml
@@ -9,10 +9,17 @@
     hosts_to_remove: "{{ [host_to_del] }}"
   when: predeleterole is defined and predeleterole != ""
 
-- name: clean host
-  include_role:
-    name: clusterverse/clean
-    tasks_from: "{{cluster_vars.type}}.yml"
+- name: remove dns and host
+  block:
+    - include_role:
+        name: clusterverse/clean
+        tasks_from: dns.yml
+      when: (hosts_to_clean | length)  and  (cluster_vars.dns_server is defined and cluster_vars.dns_server != "") and (cluster_vars.dns_user_domain is defined and cluster_vars.dns_user_domain != "")
+
+    - include_role:
+        name: clusterverse/clean
+        tasks_from: "{{cluster_vars.type}}.yml"
+      when: (hosts_to_clean | length)
   when: (hosts_to_clean | length)
   vars:
     hosts_to_clean: "{{ [host_to_del] }}"


### PR DESCRIPTION
Delete the DNS of the host being removed in the _scheme_rmvm_rmdisk_only redeploy scheme