### PR TITLE
Issue#20  new dynamic inventory

### DIFF
--- a/EXAMPLE/.gitignore
+++ b/EXAMPLE/.gitignore
@@ -6,7 +6,8 @@ inventory_*
 venv
 *.pyc
 Pipfile.lock
-roles/clusterverse
-collections/
+/roles/clusterverse
+/collections/
 /gcp__*.json
 id_rsa*
+/_dynamic_inventory/

--- a/EXAMPLE/ansible.cfg
+++ b/EXAMPLE/ansible.cfg
@@ -11,6 +11,7 @@ callbacks_enabled = ansible.posix.profile_tasks
 pipelining = yes
 ansible_async_dir = "$HOME/"
 collections_paths = ./collections:~/.ansible/collections:/usr/share/ansible/collections
+inventory = _dynamic_inventory
 
 [ssh_connection]
 retries=10

--- a/EXAMPLE/redeploy.yml
+++ b/EXAMPLE/redeploy.yml
@@ -22,3 +22,8 @@
           redeploy_var_list1:
             - "var_list1__elem1"
             - "var_list1__elem2"
+
+- name: Redeploy | Application roles
+  hosts: all
+  tasks:
+    - { include_role: { name: "testrole", apply: { tags: ["testrole"]} }, tags: ["testrole"] }

--- a/clean/tasks/main.yml
+++ b/clean/tasks/main.yml
@@ -20,26 +20,6 @@
       {%- endif -%}
 
 
-- name: clean | Delete the inventory file
-  block:
-    - name: clean | stat the inventory file to see if it exists
-      stat: path={{inventory_file}}
-      register: stat_inventory_file
-      when: inventory_file is defined
-
-    # Check the inventory_dir==playbook_dir, because the default inventory is /etc/ansible/hosts
-    - name: clean | Delete the inventory file
-      file:
-        path: "{{new_inventory_file}}"
-        state: absent
-      vars:
-        new_inventory_file: "{{ inventory_file if (((stat_inventory_file.stat is defined and stat_inventory_file.stat.exists) or (stat_inventory_file.skipped is defined and stat_inventory_file.skipped)) and inventory_dir is defined and inventory_dir==playbook_dir) else playbook_dir + '/inventory_' + cluster_name }}"
-
-
-    - name: clean | Refresh inventory
-      meta: refresh_inventory
-
-
-    - name: clean | re-acquire cluster_hosts_target and cluster_hosts_state (so the cluster_suffix will change)
-      import_role:
-        name: clusterverse/cluster_hosts
+- name: clean | Re-acquire the dynamic inventory (should cause inventory to be truncated/emptied)
+  include_role:
+    name: clusterverse/dynamic_inventory

--- a/cluster_hosts/tasks/get_cluster_hosts_target_gcp.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target_gcp.yml
@@ -45,7 +45,7 @@
           {%- for cht_host in cluster_hosts_target -%}
             {%- for r__gcp_compute_image_info_host in r__gcp_compute_image_info__by_imageid.results -%}
               {%- if r__gcp_compute_image_info_host[r__gcp_compute_image_info_host.ansible_loop_var].hostname == cht_host.hostname -%}
-                {%- set _dummy = cht_host.update({'image': (r__gcp_compute_image_info_host.resources | sort(attribute='creationTimestamp'))[-1].selfLink }) -%}
+                {%- set _dummy = cht_host.update({'image': (r__gcp_compute_image_info_host.resources | json_query('[?architecture==`X86_64`]') | sort(attribute='creationTimestamp'))[-1].selfLink }) -%}
               {%- endif %}
             {%- endfor %}
           {%- endfor %}

--- a/config/tasks/main.yml
+++ b/config/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Run cloud-specific config (if defined)
   include_tasks: "{{ item__include_tasks }}"
   loop: "{{ query('first_found', params) }}"
-  loop_control: { loop_var: item__include_tasks }   #This mechanism to include_tasks only when the file exists, also creates a loop iterator 'item' that it sends to the included tasks.  If they also have loops, we get "The loop variable 'item' is already in use" warning.
+  loop_control: { loop_var: item__include_tasks }   #This mechanism (to include_tasks only when the file exists), also creates a loop iterator 'item' that it sends to the included tasks.  If they also have loops, we get "The loop variable 'item' is already in use" warning.
   vars: { params: { files: ["config_{{cluster_vars.type}}.yml"], skip: true } }
 
 - name: Disable requiretty in sudoers to enable pipelining

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -18,7 +18,7 @@
     rules_egress:
       - proto: all
         cidr_ip: 0.0.0.0/0
-  register: r__ec2_instance_group
+  register: r__ec2_group
   when: cluster_vars.secgroup_new | length > 0
 
 - name: create/aws | Create EC2 VMs asynchronously and wait for completion
@@ -51,7 +51,7 @@
         vpc_subnet_id: "{{item.vpc_subnet_id}}"
         network:
           assign_public_ip: "{{ true if ('assign_public_ip' in cluster_vars and cluster_vars.assign_public_ip in ['dynamic'])  else  false }}"
-        security_groups: "{{ cluster_vars.secgroups_existing | default([]) + ([r__ec2_instance_group.group_name] if r__ec2_instance_group.group_name is defined else []) }}"
+        security_groups: "{{ cluster_vars.secgroups_existing | default([]) + ([r__ec2_group.group_name] if r__ec2_group.group_name is defined else []) }}"
         wait: yes
         state: running
         tags: "{{ _instance_tags | combine(cluster_vars.custom_tagslabels | default({})) }}"
@@ -144,7 +144,7 @@
       loop: "{{ cluster_hosts_target_denormalised_by_volume | selectattr('auto_volume.src', 'defined') | list }}"
       async: 7200
       poll: 0
-      register: r__ec2_instance_vol
+      register: r__ec2_vol
 
     - name: create/aws | Wait for volume creation/ attachment to complete
       async_status: { jid: "{{ item.ansible_job_id }}" }
@@ -152,7 +152,7 @@
       until: r__async_status__ec2_vol.finished
       delay: 3
       retries: 300
-      with_items: "{{r__ec2_instance_vol.results}}"
+      with_items: "{{r__ec2_vol.results}}"
 
 #    - name: create/aws | r__async_status__ec2_vol
 #      debug: msg={{r__async_status__ec2_vol}}

--- a/dynamic_inventory/tasks/main.yml
+++ b/dynamic_inventory/tasks/main.yml
@@ -34,6 +34,12 @@
   when: r__stat_inventory_sources.results | json_query('[?stat.isreg].item') | length
 
 - block:
+    - name: dynamic_inventory | create the inventory_source directory
+      ansible.builtin.file:
+        path: "{{inventory_source}}"
+        state: directory
+        mode: '0755'
+
     - name: dynamic_inventory | Get (network) facts - to determine the local IP/network, to see if we need the bastion below (requires the 'ip' tool (the 'iproute2' package on Ubuntu))
       ansible.builtin.setup: { gather_subset: ["network"] }
 
@@ -49,21 +55,11 @@
                 'ipv4_private': item.ipv4.private,
                 'hosttype': item.tagslabels.hosttype
               }) -%}
-            {%- if item.regionzone -%}
-              {%- set _dummy = res[res | length-1].update({'regionzone': item.regionzone}) -%}
-            {%- endif -%}
-            {%- if cluster_vars[buildenv].ssh_connection_cfg.host.ansible_user -%}
-              {%- set _dummy = res[res | length-1].update({'ansible_user': cluster_vars[buildenv].ssh_connection_cfg.host.ansible_user}) -%}
-            {%- endif -%}
-            {%- if 'assign_public_ip' in cluster_vars and cluster_vars.assign_public_ip in [true, 'dynamic', 'static'] -%}
-              {%- set _dummy = res[res | length-1].update({'ipv4_public': item.ipv4.public}) -%}
-            {%- endif -%}
-            {%- if cluster_vars[buildenv].ssh_connection_cfg.host.ansible_ssh_private_key_file -%}
-              {%- set _dummy = res[res | length-1].update({'ansible_ssh_private_key_file': 'id_rsa_ansible_ssh_private_key_file'}) -%}
-            {%- endif -%}
-            {%- if _bastion_host and (not _bastion_in_host_net or (force_use_bastion is defined and force_use_bastion|bool)) -%}
-              {%- set _dummy = res[res | length-1].update({'ansible_ssh_common_args': cluster_vars[buildenv].ssh_connection_cfg.bastion.ssh_args}) -%}
-            {%- endif -%}
+            {%- set _dummy = res[res | length-1].update({'regionzone': item.regionzone})  if item.regionzone else '' -%}
+            {%- set _dummy = res[res | length-1].update({'ansible_user': cluster_vars[buildenv].ssh_connection_cfg.host.ansible_user})  if cluster_vars[buildenv].ssh_connection_cfg.host.ansible_user else '' -%}
+            {%- set _dummy = res[res | length-1].update({'ipv4_public': item.ipv4.public})  if 'assign_public_ip' in cluster_vars and cluster_vars.assign_public_ip in [true, 'dynamic', 'static'] else '' -%}
+            {%- set _dummy = res[res | length-1].update({'ansible_ssh_private_key_file': 'id_rsa_ansible_ssh_private_key_file'})  if cluster_vars[buildenv].ssh_connection_cfg.host.ansible_ssh_private_key_file else '' -%}
+            {%- set _dummy = res[res | length-1].update({'ansible_ssh_common_args': cluster_vars[buildenv].ssh_connection_cfg.bastion.ssh_args})  if _bastion_host and (not _bastion_in_host_net or (force_use_bastion is defined and force_use_bastion|bool)) else '' -%}
             {%- endfor -%}
             {{ res }}
       vars:
@@ -74,27 +70,34 @@
     - name: dynamic_inventory | dynamic_inv
       debug: msg="{{ dynamic_inv }}"
 
-    - name: dynamic_inventory | create the directory
-      ansible.builtin.file:
-        path: "{{inventory_source}}"
-        state: directory
-        mode: '0755'
+    - name: dynamic_inventory | Populate (or delete) inventory files
+      block:
+        - name: dynamic_inventory | Populate inventory file from dynamic inventory (if not empty)
+          copy:
+            content: |
+              {% set groups = dynamic_inv | json_query('[].groups|[]') | unique | sort() %}
+              {% for groupname in groups -%}
+              [{{ groupname }}]
+              {% for host in dynamic_inv | json_query('[?contains(groups, \'' + groupname + '\')]') %}
+              {{ host['name'] }} ansible_host={{host['ansible_host']}} {% if 'ipv4_public' in host %}ipv4_public={{ host['ipv4_public'] }}{% endif %} ipv4_private={{ host['ipv4_private'] }} hosttype={{ host['hosttype'] }} {% if 'ansible_user' in host %}ansible_user='{{ host['ansible_user'] }}'{% endif %} {% if 'ansible_ssh_private_key_file' in host %}ansible_ssh_private_key_file='{{ host['ansible_ssh_private_key_file'] }}'{% endif %} {% if 'regionzone' in host %}regionzone={{ host['regionzone'] }}{% endif %} {% if 'ansible_ssh_common_args' in host %}ansible_ssh_common_args='{{ host['ansible_ssh_common_args'] }}'{% endif %}{{''}}
+              {% endfor %}
+              
+              {% endfor %}
+            dest: "{{item}}"
+            force: yes
+          with_items: "{{inventory_files}}"
+          when: dynamic_inv | length
 
-    - name: dynamic_inventory | Populate inventory file from dynamic inventory
-      copy:
-        content: |
-          {% set groups = dynamic_inv | json_query('[].groups|[]') | unique | sort() %}
-          {% for groupname in groups -%}
-          [{{ groupname }}]
-          {% for host in dynamic_inv | json_query('[?contains(groups, \'' + groupname + '\')]') %}
-          {{ host['name'] }} ansible_host={{host['ansible_host']}} {% if 'ipv4_public' in host %}ipv4_public={{ host['ipv4_public'] }}{% endif %} ipv4_private={{ host['ipv4_private'] }} hosttype={{ host['hosttype'] }} {% if 'ansible_user' in host %}ansible_user='{{ host['ansible_user'] }}'{% endif %} {% if 'ansible_ssh_private_key_file' in host %}ansible_ssh_private_key_file='{{ host['ansible_ssh_private_key_file'] }}'{% endif %} {% if 'regionzone' in host %}regionzone={{ host['regionzone'] }}{% endif %} {% if 'ansible_ssh_common_args' in host %}ansible_ssh_common_args='{{ host['ansible_ssh_common_args'] }}'{% endif %}{{''}}
-          {% endfor %}
-          
-          {% endfor %}
-        dest: "{{inventory_source}}/{{cur_inventory_filename}}"
-        force: yes
+        - name: dynamic_inventory | Delete inventory files if inventory is zero-length
+          file:
+            state: absent
+            path: "{{item}}"
+          with_items: "{{inventory_files}}"
+          when: dynamic_inv | length == 0
+      vars:
+        inventory_files: ["{{inventory_source}}/{{cur_inventory_filename}}", "{{playbook_dir}}/{{cur_inventory_filename}}"]
 
-    - name: dynamic_inventory | write out inventory script
+    - name: dynamic_inventory | Create inventory deletion script
       copy:
         content: |
           #!/usr/bin/env python3
@@ -120,14 +123,15 @@
         dest: "{{inventory_source}}/00-delete-non-inventory-files.py"
         force: yes
 
+      # NOTE: if the file lookup error handler is called, it returns a NoneType, which the split() filter cannot understand - hence the ternary.
     - name: dynamic_inventory | inventory file contents
-      debug: msg="{{ (lookup('file', inventory_source+'/'+cur_inventory_filename)).split('\n') | map('trim') }}"
+      debug: msg="{{ ((lookup('file', inventory_source+'/'+cur_inventory_filename, errors='ignore') | type_debug=='NoneType') | ternary('', lookup('file', inventory_source+'/'+cur_inventory_filename, errors='ignore'))).split('\n') | map('trim') }}"
   vars:
     cur_inventory_filename: "inventory__{{ app_name + ('-' + cloud_type if cloud_type is defined and cloud_type else '') + ('-' + clusterid if clusterid is defined and clusterid else '') + ('-' + region if region is defined and region else '') + ('-' + buildenv if buildenv is defined and buildenv else '') }}"
     inventory_source: "{{ansible_inventory_sources[0]}}"
   when: ((r__stat_inventory_sources.results | json_query('[?stat.exists]') | length == 0) and (ansible_inventory_sources | length == 1))  or  ((r__stat_inventory_sources.results | json_query('[?stat.exists]') | length == 1)  and  (r__stat_inventory_sources.results | json_query('[?stat.isdir]') | length == 1))
 
-  #Note: ideally this refresh_inventory would only be called within the above 'when' clause, but refresh_inventory does not support 'when', and putting it there just causes a warning.
+  #Note: Ideally this refresh_inventory would only be called within the 'when' clause, but refresh_inventory does not support 'when', and it causes a warning.
 - name: dynamic_inventory | Refresh the inventory (with the dynamically created inventory, if applicable)
   meta: refresh_inventory
 

--- a/dynamic_inventory/tasks/main.yml
+++ b/dynamic_inventory/tasks/main.yml
@@ -11,59 +11,128 @@
 - name: dynamic_inventory | cluster_hosts_state
   debug: msg="{{cluster_hosts_state}}"
 
-- name: dynamic_inventory | Refresh the in-memory inventory prior to building it (in this case, empties it, because there is no file or plugin inventory defined). This is in case this module is called multiple times, and we otherwise only add hosts to existing inventory.
-  meta: refresh_inventory
+- name: dynamic_inventory | ansible_inventory_sources
+  debug: msg="{{ansible_inventory_sources}}"
 
-- name: dynamic_inventory | Get (network) facts - to determine the local IP/network, to see if we need the bastion below (requires the 'ip' tool (the 'iproute2' package on Ubuntu))
-  ansible.builtin.setup: { gather_subset: ["network"] }
+- name: dynamic_inventory | stat the ansible_inventory_sources paths
+  stat: path={{item}}
+  register: r__stat_inventory_sources
+  with_items: "{{ansible_inventory_sources}}"
+  when: ansible_inventory_sources is defined
 
-- name: dynamic_inventory | Add hosts to dynamic inventory (add only powered-on hosts)
-  add_host:
-    name: "{{ item.name }}"
-    groups: "{{ item.tagslabels.hosttype }},{{ cluster_name }}{% if clusterid is defined and clusterid %},{{ clusterid }}{% endif %}{% if item.regionzone is defined and item.regionzone %},{{ item.regionzone }}{% endif %}{% if cluster_hosts_target is defined and item.name not in (cluster_hosts_target | default({}) | map(attribute='hostname')) %},not_target_hosts{% endif %}"
-    ansible_host: "{{ item.ipv4.public if cluster_vars.inventory_ip=='public' else item.ipv4.private }}"
-    ipv4_public: "{{ item.ipv4.public if ('assign_public_ip' in cluster_vars and cluster_vars.assign_public_ip in [true, 'dynamic', 'static'])  else  omit }}"
-    ipv4_private: "{{ item.ipv4.private }}"
-    hosttype: "{{ item.tagslabels.hosttype }}"
-    regionzone: "{{ item.regionzone if item.regionzone else omit }}"
-    ansible_ssh_common_args: "{{ cluster_vars[buildenv].ssh_connection_cfg.bastion.ssh_args if (_bastion_host and (not _bastion_in_host_net or (force_use_bastion is defined and force_use_bastion|bool))) else (omit) }}"    # Don't use the bastion if we're running in the same subnet (assumes all hosts in subnet can operate as a bastion), or if the user sets '-e force_use_bastion=true'
-    ansible_user: "{{ cluster_vars[buildenv].ssh_connection_cfg.host.ansible_user | default(omit) }}"
-    ansible_ssh_private_key_file: "{{ cluster_vars[buildenv].ssh_connection_cfg.host.ansible_ssh_private_key_file | default(None) | ternary('id_rsa_ansible_ssh_private_key_file', omit) }}"
-  with_items: "{{ cluster_hosts_state | json_query(\"[?contains(['RUNNING','running','poweredOn'], instance_state)]\") }}"
-  vars:
-    _local_cidr: "{{ (ansible_default_ipv4.network+'/'+ansible_default_ipv4.netmask) | ansible.utils.ipaddr('network/prefix') }}"                                 # Get the network the localhost IP is in
-    _bastion_host: "{{ cluster_vars[buildenv].ssh_connection_cfg.bastion.ssh_args | default() | regex_replace('.*@([]\\w\\d\\.-]*).*', '\\1') }}"   # Extract just the bastion hostname from 'cluster_vars[buildenv].ssh_connection_cfg.bastion.ssh_args'
-    _bastion_in_host_net: "{{ query('dig', _bastion_host, errors='ignore') | map('ansible.utils.ipaddr', _local_cidr) | select() | list | length > 0 }}"          # Check each bastion IP (there could be multiple results from the 'dig'), and see they're in the _local_cidr range.
+- name: dynamic_inventory | r__stat_inventory_sources
+  debug: msg="{{r__stat_inventory_sources}}"
 
+- name: "Assert that only one non-existent inventory source is defined, and if there is, that it is defined to be in playbook_dir"
+  assert:
+    that: "((r__stat_inventory_sources.results | json_query('[?stat.exists==`false`]') | length == 0)  or  ((r__stat_inventory_sources.results | json_query('[?stat.exists==`false`]') | length == 1) and (r__stat_inventory_sources.results | json_query('[?stat.exists==`false`].item | [0]') | dirname == playbook_dir)) )"
+    fail_msg: "Only a single non-existent inventory source may be defined, and if there is, it must be defined to be in playbook_dir; (ansible_inventory_sources: {{r__stat_inventory_sources.results | json_query('[?stat.exists==`false`].item')}}).  CHECK: Is 'inventory = _dynamic_inventory' set in ansible.cfg?"
 
-- name: dynamic_inventory | stat the inventory_file path
-  stat: path={{inventory_file}}
-  register: stat_inventory_file
-  when: inventory_file is defined
+- name: dynamic_inventory | Check whether we're using a manually-defined (or multiply-defined) static inventory
+  warn_str:
+    msg: "WARNING: Static inventory file(s) in use - cannot gather dynamic inventory: {{ r__stat_inventory_sources.results | json_query(\"[?stat.isreg].item \") }}"
+  when: r__stat_inventory_sources.results | json_query('[?stat.isreg].item') | length
 
 - block:
+    - name: dynamic_inventory | Get (network) facts - to determine the local IP/network, to see if we need the bastion below (requires the 'ip' tool (the 'iproute2' package on Ubuntu))
+      ansible.builtin.setup: { gather_subset: ["network"] }
+
+    - name: dynamic_inventory | Add (powered-on) hosts to dynamic inventory
+      set_fact:
+        dynamic_inv: |
+          {% set res = [] -%}
+          {%- for item in cluster_hosts_state | json_query('[?contains([\'RUNNING\',\'running\',\'poweredOn\'], instance_state)]') | sort(attribute='name') -%}
+            {%- set _dummy = res.append({
+                'name': item.name,
+                'groups': [item.tagslabels.hosttype] + [cluster_name] + ([clusterid] if clusterid is defined and clusterid else []) + ([item.regionzone] if item.regionzone is defined and item.regionzone else []) + (['not_target_hosts'] if cluster_hosts_target is defined and item.name not in (cluster_hosts_target | default({}) | map(attribute='hostname')) else []),
+                'ansible_host': item.ipv4.public if cluster_vars.inventory_ip=='public' else item.ipv4.private,
+                'ipv4_private': item.ipv4.private,
+                'hosttype': item.tagslabels.hosttype
+              }) -%}
+            {%- if item.regionzone -%}
+              {%- set _dummy = res[res | length-1].update({'regionzone': item.regionzone}) -%}
+            {%- endif -%}
+            {%- if cluster_vars[buildenv].ssh_connection_cfg.host.ansible_user -%}
+              {%- set _dummy = res[res | length-1].update({'ansible_user': cluster_vars[buildenv].ssh_connection_cfg.host.ansible_user}) -%}
+            {%- endif -%}
+            {%- if 'assign_public_ip' in cluster_vars and cluster_vars.assign_public_ip in [true, 'dynamic', 'static'] -%}
+              {%- set _dummy = res[res | length-1].update({'ipv4_public': item.ipv4.public}) -%}
+            {%- endif -%}
+            {%- if cluster_vars[buildenv].ssh_connection_cfg.host.ansible_ssh_private_key_file -%}
+              {%- set _dummy = res[res | length-1].update({'ansible_ssh_private_key_file': 'id_rsa_ansible_ssh_private_key_file'}) -%}
+            {%- endif -%}
+            {%- if _bastion_host and (not _bastion_in_host_net or (force_use_bastion is defined and force_use_bastion|bool)) -%}
+              {%- set _dummy = res[res | length-1].update({'ansible_ssh_common_args': cluster_vars[buildenv].ssh_connection_cfg.bastion.ssh_args}) -%}
+            {%- endif -%}
+            {%- endfor -%}
+            {{ res }}
+      vars:
+        _local_cidr: "{{ (ansible_default_ipv4.network+'/'+ansible_default_ipv4.netmask) | ansible.utils.ipaddr('network/prefix') }}"                                 # Get the network the localhost IP is in
+        _bastion_host: "{{ cluster_vars[buildenv].ssh_connection_cfg.bastion.ssh_args | default() | regex_replace('.*@([]\\w\\d\\.-]*).*', '\\1') }}"                 # Extract just the bastion hostname from 'cluster_vars[buildenv].ssh_connection_cfg.bastion.ssh_args'
+        _bastion_in_host_net: "{{ query('dig', _bastion_host, errors='ignore') | map('ansible.utils.ipaddr', _local_cidr) | select() | list | length > 0 }}"          # Check each bastion IP (there could be multiple results from the 'dig'), and see they're in the _local_cidr range.
+
+    - name: dynamic_inventory | dynamic_inv
+      debug: msg="{{ dynamic_inv }}"
+
+    - name: dynamic_inventory | create the directory
+      ansible.builtin.file:
+        path: "{{inventory_source}}"
+        state: directory
+        mode: '0755'
+
     - name: dynamic_inventory | Populate inventory file from dynamic inventory
       copy:
         content: |
-          {% for groupname in groups.keys() | sort() -%}
-          {% if groupname not in ["all", "ungrouped"] -%}
+          {% set groups = dynamic_inv | json_query('[].groups|[]') | unique | sort() %}
+          {% for groupname in groups -%}
           [{{ groupname }}]
-          {% for hostname in groups[groupname] | sort() %}
-          {{ hostname }} ansible_host={{hostvars[hostname].ansible_host}} {% if 'ipv4_public' in hostvars[hostname] %}ipv4_public={{ hostvars[hostname].ipv4_public }}{% endif %} ipv4_private={{ hostvars[hostname].ipv4_private }} hosttype={{ hostvars[hostname].hosttype }} {% if 'ansible_user' in hostvars[hostname] %}ansible_user='{{ hostvars[hostname].ansible_user }}'{% endif %} {% if 'ansible_ssh_private_key_file' in hostvars[hostname] %}ansible_ssh_private_key_file='{{ hostvars[hostname].ansible_ssh_private_key_file }}'{% endif %} {% if 'regionzone' in hostvars[hostname] %}regionzone={{ hostvars[hostname].regionzone }}{% endif %} {% if 'ansible_ssh_common_args' in hostvars[hostname] %}ansible_ssh_common_args='{{ hostvars[hostname].ansible_ssh_common_args }}'{% endif %}{{''}}
+          {% for host in dynamic_inv | json_query('[?contains(groups, \'' + groupname + '\')]') %}
+          {{ host['name'] }} ansible_host={{host['ansible_host']}} {% if 'ipv4_public' in host %}ipv4_public={{ host['ipv4_public'] }}{% endif %} ipv4_private={{ host['ipv4_private'] }} hosttype={{ host['hosttype'] }} {% if 'ansible_user' in host %}ansible_user='{{ host['ansible_user'] }}'{% endif %} {% if 'ansible_ssh_private_key_file' in host %}ansible_ssh_private_key_file='{{ host['ansible_ssh_private_key_file'] }}'{% endif %} {% if 'regionzone' in host %}regionzone={{ host['regionzone'] }}{% endif %} {% if 'ansible_ssh_common_args' in host %}ansible_ssh_common_args='{{ host['ansible_ssh_common_args'] }}'{% endif %}{{''}}
           {% endfor %}
+          
+          {% endfor %}
+        dest: "{{inventory_source}}/{{cur_inventory_filename}}"
+        force: yes
 
-          {% endif %}
-          {% endfor %}
-        dest: "{{new_inventory_file}}"
+    - name: dynamic_inventory | write out inventory script
+      copy:
+        content: |
+          #!/usr/bin/env python3
+
+          import os, sys, json
+
+          inventory_filename = "{{cur_inventory_filename}}"
+          script_directory = os.path.dirname(os.path.abspath(__file__))
+          script_filename = os.path.basename(__file__)
+
+          try:
+              for filename in os.listdir(script_directory):
+                  if filename not in [inventory_filename, script_filename]:
+                      file_path = os.path.join(script_directory, filename)
+                      if os.path.isfile(file_path):
+                          os.remove(file_path)
+          except Exception as e:
+              sys.stderr.write("An error occurred: " + str(e) + "\n")
+              sys.exit(1)
+
+          print(json.dumps({'_meta': {'hostvars': {}}}))
+        mode: 0755
+        dest: "{{inventory_source}}/00-delete-non-inventory-files.py"
         force: yes
 
     - name: dynamic_inventory | inventory file contents
-      debug: msg="{{ (lookup('file', new_inventory_file)).split('\n') | map('trim') }}"
+      debug: msg="{{ (lookup('file', inventory_source+'/'+cur_inventory_filename)).split('\n') | map('trim') }}"
   vars:
-    new_inventory_file: "{{ inventory_file if (((stat_inventory_file.stat is defined and stat_inventory_file.stat.exists) or (stat_inventory_file.skipped is defined and stat_inventory_file.skipped)) and inventory_dir is defined and inventory_dir==playbook_dir) else playbook_dir + '/inventory_' + cluster_name }}"
+    cur_inventory_filename: "inventory__{{ app_name + ('-' + cloud_type if cloud_type is defined and cloud_type else '') + ('-' + clusterid if clusterid is defined and clusterid else '') + ('-' + region if region is defined and region else '') + ('-' + buildenv if buildenv is defined and buildenv else '') }}"
+    inventory_source: "{{ansible_inventory_sources[0]}}"
+  when: ((r__stat_inventory_sources.results | json_query('[?stat.exists]') | length == 0) and (ansible_inventory_sources | length == 1))  or  ((r__stat_inventory_sources.results | json_query('[?stat.exists]') | length == 1)  and  (r__stat_inventory_sources.results | json_query('[?stat.isdir]') | length == 1))
+
+  #Note: ideally this refresh_inventory would only be called within the above 'when' clause, but refresh_inventory does not support 'when', and putting it there just causes a warning.
+- name: dynamic_inventory | Refresh the inventory (with the dynamically created inventory, if applicable)
+  meta: refresh_inventory
 
 - name: dynamic_inventory | current inventory_hostnames
-  debug: msg="{{ query('inventory_hostnames','all', errors='ignore') }}"
+  debug: msg="{{ query('inventory_hostnames','all', errors='ignore') | sort() }}"
 
 
 ### Ideally, we would like to verify that each host is contactable at this point.  However, no combination of the normal Ansible modules allow this.


### PR DESCRIPTION
A new mechanism for clean-refreshing the dynamic inventory is needed, as the behaviour of `meta: refresh_inventory` was changed in https://github.com/ansible/ansible/pull/77944 (from https://github.com/ansible/ansible/issues/59400), so that hosts added by `add_host` are preserved. Because clusterverse has hitherto relied on `add_host` exclusively to build the inventory, it relied on the old behaviour to clear the inventory completely after a redeploy.

Options:

+ It is apparently not possible to write an action plugin to modify the play-level inventory, as action plugins appear to use a temporary copy of the inventory.

+ It would be possible to save the 'deleted' hosts as a group, and then exclude these hosts in the playbook (i.e. `hosts: all:!deleted`), but that feels like an anti-pattern, which relies on the user of clusterverse having intimate knowledge of its inner workings.

+ The method employed here leverages the ability of Ansible to specify a directory as an inventory source (set `inventory = _dynamic_inventory` in `ansible.cfg`), and for the directory to contain both scripts and inventory files.
  + When the `dynamic_inventory/tasks/main.yml` runs, it operates as before, creating `cluster_hosts_state`; from this it builds a dynamic inventory.
  + It writes this inventory to the inventory_sources directory defined in `ansible.cfg` (_dynamic_inventory/<filename>).
  + It also writes a small python script (`_dynamic_inventory/00-delete-non-inventory-files.py`) to delete all other files from that directory.
  + It then performs a `meta: refresh_inventory`.  This first causes the script to run (deleting and old inventories), and the newly-written inventory to be parsed as normal.

Fixes #20 

Also included in here, a fix for `gcp_compute_image_info`, which now returns ARM64 as well as  X86_64 images. It allows you to install ARM64 images onto a machine flavour that only supports X86_64, and there's currently no API that allows you to determine which architecture is supported by which flavour.  This just filters out the ARM64 images (as they're only supported on T2A machines so far)