### PR TITLE
Remove endpoint_url, as it was included only for the ec2 module, which used legacy boto

### DIFF
--- a/EXAMPLE/cluster_defs/aws/cluster_vars__cloud.yml
+++ b/EXAMPLE/cluster_defs/aws/cluster_vars__cloud.yml
@@ -4,7 +4,6 @@
 ssh_whitelist:  ['10.0.0.0/8']
 
 cluster_vars:
-  aws_endpoint_url: https://ec2.{{region}}.amazonaws.com      # Some of the regions are not available for aws module boto.ec2. If the region definitely exists, you may need to upgrade boto or extend with endpoints_path.  Adding this to ec2 invocation fixes the issue
   dns_cloud_internal_domain: "{{region}}.compute.internal"    # The cloud-internal zone as defined by the cloud provider (e.g. GCP, AWS)
   dns_nameserver_zone: &dns_nameserver_zone ""                # The zone that dns_server will operate on.  gcloud dns needs a trailing '.'.  Leave blank if no external DNS (use IPs only)
   dns_user_domain: "{%- if _dns_nameserver_zone -%}{{cloud_type}}-{{region}}.{{app_class}}.{{buildenv}}.{{_dns_nameserver_zone}}{%- endif -%}"         # A user-defined _domain_ part of the FDQN, (if more prefixes are required before the dns_nameserver_zone)

--- a/clean/tasks/aws.yml
+++ b/clean/tasks/aws.yml
@@ -7,7 +7,6 @@
         access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         session_token: "{{cluster_vars[buildenv].aws_session_token | default(omit)}}"
-        endpoint_url: "{{ cluster_vars.aws_endpoint_url | default(omit) }}"
         region: "{{ cluster_vars.region }}"
         state: "{{ item.instance_state }}"
         termination_protection: false
@@ -19,7 +18,6 @@
         access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         session_token: "{{cluster_vars[buildenv].aws_session_token | default(omit)}}"
-        endpoint_url: "{{ cluster_vars.aws_endpoint_url | default(omit) }}"
         region: "{{ cluster_vars.region }}"
         state: "absent"
         instance_ids: "{{ hosts_to_clean | json_query(\"[].instance_id\") }}"

--- a/create/tasks/create_aws.yml
+++ b/create/tasks/create_aws.yml
@@ -39,7 +39,6 @@
         access_key: "{{cluster_vars[buildenv].aws_access_key}}"
         secret_key: "{{cluster_vars[buildenv].aws_secret_key}}"
         session_token: "{{cluster_vars[buildenv].aws_session_token | default(omit)}}"
-        endpoint_url: "{{ cluster_vars.aws_endpoint_url | default(omit) }}"
         region: "{{cluster_vars.region}}"
         key_name: "{{cluster_vars[buildenv].key_name}}"
         instance_type: "{{item.flavor}}"


### PR DESCRIPTION
Legacy boto did not support some AWS regions.  We are now using amazon.aws.ec2_instance which uses boto3 and supports all regions, so endpoint_url is redundant.