### PR TITLE
Add variable `allow_empty_hosttype_in_hostname` 

### DIFF
--- a/EXAMPLE/README.md
+++ b/EXAMPLE/README.md
@@ -52,6 +52,7 @@ ansible-playbook cluster.yml -e buildenv=sandbox -e cloud_type=esxifree --vault-
 ### Optional extra variables:
 + `-e app_name=<nginx>` - Normally defined in `/cluster_defs/`.  The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name
 + `-e app_class=<proxy>` - Normally defined in `/cluster_defs/`.  The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
++ `-e allow_empty_hosttype_in_hostname=[true|false]` - Allow empty hosttype in hostname when there is only one hosttype in the cluster.
 + `-e clean=[current|retiring|redeployfail|_all_]` - Deletes VMs in `lifecycle_state`, or `_all_`, as well as networking and security groups
 + `-e pkgupdate=[always|on_create]` - Upgrade the OS packages (not good for determinism).  `on_create` only upgrades when creating the VM for the first time.
 + `-e reboot_on_package_upgrade=true` - After updating packages, performs a reboot on all nodes.

--- a/EXAMPLE/README.md
+++ b/EXAMPLE/README.md
@@ -52,7 +52,7 @@ ansible-playbook cluster.yml -e buildenv=sandbox -e cloud_type=esxifree --vault-
 ### Optional extra variables:
 + `-e app_name=<nginx>` - Normally defined in `/cluster_defs/`.  The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name
 + `-e app_class=<proxy>` - Normally defined in `/cluster_defs/`.  The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
-+ `-e allow_empty_hosttype_in_hostname=[true|false]` - Allow empty hosttype in hostname when there is only one hosttype in the cluster.
++ `-e omit_singleton_hosttype_from_hostname=[true|false]` - When there is only one hosttype in the cluster, whether to omit the hosttype from the hostname, (e.g. bastion-dev-node-a0 -> bastion-dev-a0).  DO NOT use when there is a chance you will need it in future.
 + `-e clean=[current|retiring|redeployfail|_all_]` - Deletes VMs in `lifecycle_state`, or `_all_`, as well as networking and security groups
 + `-e pkgupdate=[always|on_create]` - Upgrade the OS packages (not good for determinism).  `on_create` only upgrades when creating the VM for the first time.
 + `-e reboot_on_package_upgrade=true` - After updating packages, performs a reboot on all nodes.

--- a/EXAMPLE/cluster_defs/cluster_vars.yml
+++ b/EXAMPLE/cluster_defs/cluster_vars.yml
@@ -2,8 +2,6 @@
 
 redeploy_schemes_supported: ['_scheme_addallnew_rmdisk_rollback', '_scheme_addnewvm_rmdisk_rollback', '_scheme_rmvm_rmdisk_only', '_scheme_rmvm_keepdisk_rollback', '_noredeploy_scale_in_only']
 
-test_touch_disks: false
-
 app_name: "{{lookup('pipe', 'whoami') | lower}}-test"   # The name of the application cluster (e.g. 'couchbase', 'nginx'); becomes part of cluster_name.  Provided is a default to ensure no accidental overwriting.
 app_class: "test"                                       # The class of application (e.g. 'database', 'webserver'); becomes part of the fqdn
 

--- a/_dependencies/defaults/main.yml
+++ b/_dependencies/defaults/main.yml
@@ -22,6 +22,9 @@ chrony_install: true
 # NTP servers for chrony
 chrony_ntp_servers: "{{ ['169.254.169.123 prefer iburst minpoll 4 maxpoll 4'] if cluster_vars.type == 'aws' else ['metadata.google.internal'] if cluster_vars.type == 'gcp' else ['pool.ntp.org'] }}"
 
+# Whether to allow empty hosttype in hostname, when there is only one hosttype in the cluster
+allow_empty_hosttype_in_hostname: true
+
 # remove snapd for ubuntu
 remove_snapd: true
 

--- a/_dependencies/defaults/main.yml
+++ b/_dependencies/defaults/main.yml
@@ -22,8 +22,8 @@ chrony_install: true
 # NTP servers for chrony
 chrony_ntp_servers: "{{ ['169.254.169.123 prefer iburst minpoll 4 maxpoll 4'] if cluster_vars.type == 'aws' else ['metadata.google.internal'] if cluster_vars.type == 'gcp' else ['pool.ntp.org'] }}"
 
-# Whether to allow empty hosttype in hostname, when there is only one hosttype in the cluster
-allow_empty_hosttype_in_hostname: true
+# When there is only one hosttype in the cluster, whether to omit the hosttype from the hostname, (e.g. bastion-dev-node-a0 -> bastion-dev-a0).  This is useful when the hosttype is not relevant.  DO NOT use when there is a chance you will need it in future
+omit_singleton_hosttype_from_hostname: false
 
 # remove snapd for ubuntu
 remove_snapd: true

--- a/_dependencies/tasks/main.yml
+++ b/_dependencies/tasks/main.yml
@@ -91,7 +91,6 @@
         galaxy_collections: "{{lookup('pipe', 'ansible-galaxy collection list --format=json', errors='ignore') | from_json | json_query(\"*\") | combine }}"
 
     - assert: { that: "app_name is defined and app_name != ''", fail_msg: "Please define app_name" }
-    - assert: { that: "app_class is defined and app_class != ''", fail_msg: "Please define app_class" }
     - assert: { that: "cluster_vars is defined", fail_msg: "Please define cluster_vars" }
     - assert: { that: "buildenv is defined and cluster_vars[buildenv] is defined", fail_msg: "Please define buildenv" }
 

--- a/cluster_hosts/meta/main.yml
+++ b/cluster_hosts/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - role: '_dependencies'

--- a/cluster_hosts/tasks/get_cluster_hosts_target.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target.yml
@@ -10,7 +10,7 @@
           {%- for azcount in range(0,cluster_vars[buildenv].hosttype_vars[hosttype].vms_by_az[azname]|int) -%}
             {% set _dummy = res.extend([{
               'hosttype': hosttype,
-              'hostname': cluster_name + '-' + hosttype + '-' + azname|string + azcount|string + '-' + cluster_suffix|string,
+              'hostname': cluster_name + '-' + ('' if (allow_empty_hosttype_in_hostname is defined and allow_empty_hosttype_in_hostname|bool) and (cluster_vars[buildenv].hosttype_vars.keys() | length==1) else (hosttype + '-')) + azname|string + azcount|string + '-' + cluster_suffix|string,
               'az_name': azname|string,
               'flavor': cluster_vars[buildenv].hosttype_vars[hosttype].flavor,
               'image': cluster_vars[buildenv].hosttype_vars[hosttype].image | default(cluster_vars.image),

--- a/cluster_hosts/tasks/get_cluster_hosts_target.yml
+++ b/cluster_hosts/tasks/get_cluster_hosts_target.yml
@@ -10,7 +10,7 @@
           {%- for azcount in range(0,cluster_vars[buildenv].hosttype_vars[hosttype].vms_by_az[azname]|int) -%}
             {% set _dummy = res.extend([{
               'hosttype': hosttype,
-              'hostname': cluster_name + '-' + ('' if (allow_empty_hosttype_in_hostname is defined and allow_empty_hosttype_in_hostname|bool) and (cluster_vars[buildenv].hosttype_vars.keys() | length==1) else (hosttype + '-')) + azname|string + azcount|string + '-' + cluster_suffix|string,
+              'hostname': cluster_name + '-' + ((hosttype + '-') if (omit_singleton_hosttype_from_hostname is not defined or not omit_singleton_hosttype_from_hostname|bool or (cluster_vars[buildenv].hosttype_vars.keys() | length > 1)) else '') + azname|string + azcount|string + '-' + cluster_suffix|string,
               'az_name': azname|string,
               'flavor': cluster_vars[buildenv].hosttype_vars[hosttype].flavor,
               'image': cluster_vars[buildenv].hosttype_vars[hosttype].image | default(cluster_vars.image),

--- a/config/tasks/pkgs.yml
+++ b/config/tasks/pkgs.yml
@@ -22,6 +22,7 @@
         allow_change_held_packages: true
         autoremove: true
         purge: true
+      register: r__apt_remove_snapd
 
 # Note: Doesn't work on Unbuntu 16.04
 #    - name: config/pkgs | prevent snapd installing with apt upgrade
@@ -33,6 +34,7 @@
     - name: config/pkgs | prevent snapd installing with apt upgrade
       become: true
       ansible.builtin.shell: apt-mark hold snapd
+      when: r__apt_remove_snapd.changed
   when: ansible_os_family == 'Debian' and (remove_snapd is defined and remove_snapd|bool)
 
 - name: config/pkgs | upgrade all packages, reboot and wait (if reboot_on_package_upgrade==true)

--- a/config/tasks/pkgs.yml
+++ b/config/tasks/pkgs.yml
@@ -70,4 +70,4 @@
           ansible.builtin.wait_for_connection:
             timeout: 120
       when: (reboot_on_package_upgrade is defined and reboot_on_package_upgrade|bool) and (apt_packages_update.changed or yum_packages_update.changed)
-  when: pkgupdate is defined and (pkgupdate == 'always' or (pkgupdate in ['onCreate', 'on_create'] and inventory_hostname in (hostvars['localhost'].cluster_hosts_created | json_query('[].hostname'))))
+  when: pkgupdate is defined and (pkgupdate == 'always' or (pkgupdate in ['onCreate', 'on_create'] and inventory_hostname in (hostvars['localhost'].cluster_hosts_created | default([]) | json_query('[].hostname'))))


### PR DESCRIPTION
Set to true (by default), in order to allow empty hosttype in hostname, when there is only one hosttype in the cluster.

Created because many clusters are a single type of host, and this otherwise makes the hostname needlessly long.